### PR TITLE
feat: Update RPC types based on upcoming node API changes

### DIFF
--- a/.changeset/hip-aliens-work.md
+++ b/.changeset/hip-aliens-work.md
@@ -1,0 +1,12 @@
+---
+"@cartesi/rpc": patch
+---
+
+Update RPC types and methods. It has breaking changes.
+
+- Added new EpochStatus [CLAIM_REJECTED, CLAIM_FORECLOSED]
+- Rename ApplicationState to ApplicationStatus. It has a new union [OK, FAILED, DIVERGED, CORRUPTED]. ENABLED and DISABLED states were removed.
+- Application has a new property called `enabled`.
+- Added new fields to the Application type.
+- New Withdrawal type added.
+- Added new json rpc methods [cartesi_getWithdrawal, cartesi_listWithdrawals]

--- a/.changeset/tender-rings-sneeze.md
+++ b/.changeset/tender-rings-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/viem": patch
+---
+
+Implement the new methods getWithdrawal and listWithdrawals including the new withdrawal converter. Also update the application-converter.

--- a/.changeset/tiny-masks-turn.md
+++ b/.changeset/tiny-masks-turn.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/wagmi": patch
+---
+
+Add react hooks for get-withdrawal and list-withdrawals JSON-RPC API methods.

--- a/apps/docs/pages/rpc/cartesi_getWithdrawal.mdx
+++ b/apps/docs/pages/rpc/cartesi_getWithdrawal.mdx
@@ -1,0 +1,18 @@
+# cartesi_getWithdrawal
+
+## Usage
+
+```ts twoslash
+// [!include ~/snippets/rpc/createClient.ts]
+
+const { data: withdrawal } = await client.request("cartesi_getWithdrawal", {
+    application: "0x0974CC873dF893B302f6be7ecf4F9D4b1A15C366",
+    account_index: "0x2A",
+});
+```
+
+## Return Type
+
+```ts twoslash
+import { type Withdrawal } from "@cartesi/rpc";
+```

--- a/apps/docs/pages/rpc/cartesi_listWithdrawals.mdx
+++ b/apps/docs/pages/rpc/cartesi_listWithdrawals.mdx
@@ -1,0 +1,33 @@
+# cartesi_listWithdrawals
+
+## Usage
+
+```ts twoslash
+// [!include ~/snippets/rpc/createClient.ts]
+
+const { data, pagination } = await client.request("cartesi_listWithdrawals", {
+    application: "0x0974CC873dF893B302f6be7ecf4F9D4b1A15C366",
+    limit: 50,
+    offset: 0,
+});
+```
+
+## Filters
+
+The request can filter results by:
+
+- `account_index: HexNumber`
+
+```ts twoslash
+import { type HexNumber } from "@cartesi/rpc";
+```
+
+## Return Type
+
+The `data` is an array of `Withdrawal`:
+
+```ts twoslash
+import { type Withdrawal, type ListWithdrawalsReturnType } from "@cartesi/rpc";
+```
+
+For more information about pagination refer to the [pagination section](/rpc#pagination).

--- a/apps/docs/pages/rpc/index.mdx
+++ b/apps/docs/pages/rpc/index.mdx
@@ -15,6 +15,7 @@ cartesi_getMatchAdvanced
 cartesi_getInput
 cartesi_getOutput
 cartesi_getReport
+cartesi_getWithdrawal
 
 cartesi_listApplications
 cartesi_listEpochs
@@ -25,6 +26,7 @@ cartesi_listMatchAdvances
 cartesi_listInputs
 cartesi_listOutputs
 cartesi_listReports
+cartesi_listWithdrawals
 ```
 
 ## Applications

--- a/apps/docs/pages/viem/getWithdrawal.mdx
+++ b/apps/docs/pages/viem/getWithdrawal.mdx
@@ -1,0 +1,34 @@
+# getWithdrawal
+
+## Usage
+
+```ts twoslash
+import { http } from "viem";
+import { createCartesiPublicClient } from "@cartesi/viem";
+
+const publicClientL2 = createCartesiPublicClient({
+    transport: http("http://127.0.0.1:6751/rpc"),
+});
+
+const withdrawal = await publicClientL2.getWithdrawal({
+    application: "0x...",
+    accountIndex: 1n,
+});
+```
+
+## Parameters
+
+```ts twoslash
+import type { GetWithdrawalParams } from "@cartesi/viem";
+// {
+//  application: string | Address;
+//  accountIndex: bigint;
+// }
+```
+
+## Return Type
+
+```ts twoslash
+import type { GetWithdrawalReturnType, Withdrawal } from "@cartesi/viem";
+// type GetWithdrawalReturnType = Withdrawal
+```

--- a/apps/docs/pages/viem/listWithdrawals.mdx
+++ b/apps/docs/pages/viem/listWithdrawals.mdx
@@ -1,0 +1,46 @@
+# listWithdrawals
+
+## Usage
+
+```ts twoslash
+import { http } from "viem";
+import { createCartesiPublicClient } from "@cartesi/viem";
+
+const publicClientL2 = createCartesiPublicClient({
+    transport: http("http://127.0.0.1:6751/rpc"),
+});
+
+const { data, pagination } = await publicClientL2.listWithdrawals({
+    application: "0x...",
+    limit: 10,
+    offset: 0,
+    // accountIndex (optional)
+});
+```
+
+## Parameters
+
+```ts twoslash
+import type { ListWithdrawalsParams } from "@cartesi/viem";
+// {
+//   application: Address | string;
+//   accountIndex?: bigint;
+//   limit?: number;
+//   offset?: number;
+//   descending?: boolean;
+// }
+```
+
+## Return Type
+
+```ts twoslash
+import type {
+    ListWithdrawalsReturnType,
+    Withdrawal,
+    Pagination,
+} from "@cartesi/viem";
+// ListWithdrawalsReturnType = {
+//   data: Withdrawal[];
+//   pagination: Pagination;
+// }
+```

--- a/apps/docs/pages/wagmi/useWithdrawal.mdx
+++ b/apps/docs/pages/wagmi/useWithdrawal.mdx
@@ -1,0 +1,23 @@
+# useWithdrawal
+
+## Usage
+
+```tsx twoslash
+import { useWithdrawal } from "@cartesi/wagmi";
+
+function Example() {
+    const { data, isLoading } = useWithdrawal({
+        application: "0x...",
+        accountIndex: 0n,
+    });
+    // render logic
+}
+```
+
+## Return Type
+
+The `data` is a `Withdrawal`:
+
+```ts twoslash
+import { type Withdrawal, type GetWithdrawalReturnType } from "@cartesi/viem";
+```

--- a/apps/docs/pages/wagmi/useWithdrawals.mdx
+++ b/apps/docs/pages/wagmi/useWithdrawals.mdx
@@ -1,0 +1,41 @@
+# useWithdrawals
+
+## Usage
+
+```tsx twoslash
+import { useWithdrawals } from "@cartesi/wagmi";
+
+function Example() {
+    const { data, isLoading } = useWithdrawals({
+        application: "0x1234567890abcdef1234567890abcdef12345678",
+        limit: 50,
+        offset: 0,
+        // accountIndex: 0n, // optional
+    });
+    const { data: withdrawals, pagination } = data || {};
+    // render logic
+}
+```
+
+## Filters
+
+The hook can filter results by:
+
+- `application: Address | string`
+- `accountIndex?: bigint`
+
+```ts twoslash
+import type { ListWithdrawalsParams } from "@cartesi/viem";
+```
+
+## Return Type
+
+The `data` is an object of type `ListWithdrawalsReturnType`:
+
+```ts twoslash
+import type {
+    Withdrawal,
+    ListWithdrawalsReturnType,
+    Pagination,
+} from "@cartesi/viem";
+```

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -138,6 +138,11 @@ const config: Config = defineConfig({
                             text: "getLastAcceptedEpochIndex",
                             link: "/viem/getLastAcceptedEpochIndex",
                         },
+                        { text: "getWithdrawal", link: "/viem/getWithdrawal" },
+                        {
+                            text: "listWithdrawals",
+                            link: "/viem/listWithdrawals",
+                        },
                         { text: "waitForInput", link: "viem/waitForInput" },
                     ],
                 },
@@ -206,6 +211,14 @@ const config: Config = defineConfig({
                         {
                             text: "useWaitForInput",
                             link: "/wagmi/useWaitForInput",
+                        },
+                        {
+                            text: "useWithdrawal",
+                            link: "/wagmi/useWithdrawal",
+                        },
+                        {
+                            text: "useWithdrawals",
+                            link: "/wagmi/useWithdrawals",
                         },
                     ],
                 },
@@ -311,6 +324,14 @@ const config: Config = defineConfig({
                         {
                             text: "cartesi_getReport",
                             link: "/rpc/cartesi_getReport",
+                        },
+                        {
+                            text: "cartesi_getWithdrawal",
+                            link: "/rpc/cartesi_getWithdrawal",
+                        },
+                        {
+                            text: "cartesi_listWithdrawals",
+                            link: "/rpc/cartesi_listWithdrawals",
                         },
                     ],
                 },

--- a/packages/rpc/src/methods.ts
+++ b/packages/rpc/src/methods.ts
@@ -23,6 +23,8 @@ import type {
     GetReportReturnType,
     GetTournamentParams,
     GetTournamentReturnType,
+    GetWithdrawalParams,
+    GetWithdrawalReturnType,
     ListApplicationsParams,
     ListApplicationsReturnType,
     ListCommitmentsParams,
@@ -41,6 +43,8 @@ import type {
     ListReportsReturnType,
     ListTournamentsParams,
     ListTournamentsReturnType,
+    ListWithdrawalsParams,
+    ListWithdrawalsReturnType,
 } from "./types.js";
 
 export type Methods = {
@@ -82,4 +86,8 @@ export type Methods = {
     cartesi_getReport(params: GetReportParams): GetReportReturnType;
     cartesi_getChainId(): GetChainIdReturnType;
     cartesi_getNodeVersion(): GetNodeVersionReturnType;
+    cartesi_listWithdrawals(
+        params: ListWithdrawalsParams,
+    ): ListWithdrawalsReturnType;
+    cartesi_getWithdrawal(params: GetWithdrawalParams): GetWithdrawalReturnType;
 };

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -29,7 +29,8 @@ export type EpochStatus =
     | "CLAIM_SUBMITTED"
     | "CLAIM_STAGED"
     | "CLAIM_ACCEPTED"
-    | "CLAIM_REJECTED";
+    | "CLAIM_REJECTED"
+    | "CLAIM_FORECLOSED";
 
 export type InputStatus =
     | "NONE"
@@ -44,7 +45,7 @@ export type InputStatus =
 
 export type ConsensusType = "AUTHORITY" | "QUORUM" | "PRT";
 
-export type ApplicationState = "ENABLED" | "DISABLED" | "FAILED" | "INOPERABLE";
+export type ApplicationStatus = "OK" | "FAILED" | "DIVERGED" | "CORRUPTED";
 
 export type SnapshotPolicy = "NONE" | "EVERY_INPUT" | "EVERY_EPOCH";
 
@@ -69,15 +70,23 @@ export type Application = {
     withdrawal_config: WithdrawalConfig;
     data_availability: Hex;
     consensus_type: ConsensusType;
-    state: ApplicationState;
+    enabled: boolean;
+    status: ApplicationStatus;
     reason?: string | null;
     iinputbox_block: HexNumber;
     last_epoch_check_block: HexNumber;
     last_input_check_block: HexNumber;
     last_output_check_block: HexNumber;
     last_tournament_check_block: HexNumber;
-    foreclose_search_last_block: HexNumber;
+    last_foreclose_check_block: HexNumber;
+    last_accounts_drive_proved_check_block: HexNumber;
+    last_withdrawal_check_block: HexNumber;
     processed_inputs: HexNumber;
+    foreclose_block: HexNumber;
+    foreclose_transaction: Hash;
+    accounts_drive_proved_block: HexNumber;
+    accounts_drive_proved_transaction: Hash;
+    accounts_drive_merkle_root: Hash;
     created_at: DateTime;
     updated_at: DateTime;
     execution_parameters: {
@@ -420,4 +429,31 @@ export type GetChainIdReturnType = {
 
 export type GetNodeVersionReturnType = {
     data: string;
+};
+
+export type Withdrawal = {
+    account_index: HexNumber;
+    account: Hex;
+    output: Hex;
+    block_number: HexNumber;
+    transaction_hash: Hash;
+    log_index: HexNumber;
+    created_at: DateTime;
+    updated_at: DateTime;
+};
+
+export type ListWithdrawalsParams = PaginationParams & {
+    application: string | Address;
+    account_index?: HexNumber;
+};
+
+export type ListWithdrawalsReturnType = PaginatedReturnType<Withdrawal>;
+
+export type GetWithdrawalParams = {
+    application: string | Address;
+    account_index: HexNumber;
+};
+
+export type GetWithdrawalReturnType = {
+    data: Withdrawal;
 };

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -27,6 +27,7 @@ export type EpochStatus =
     | "INPUTS_PROCESSED"
     | "CLAIM_COMPUTED"
     | "CLAIM_SUBMITTED"
+    | "CLAIM_STAGED"
     | "CLAIM_ACCEPTED"
     | "CLAIM_REJECTED";
 
@@ -64,6 +65,8 @@ export type Application = {
     iinputbox_address: Address;
     template_hash: Hash;
     epoch_length: HexNumber;
+    claim_staging_period: HexNumber;
+    withdrawal_config: WithdrawalConfig;
     data_availability: Hex;
     consensus_type: ConsensusType;
     state: ApplicationState;
@@ -72,6 +75,8 @@ export type Application = {
     last_epoch_check_block: HexNumber;
     last_input_check_block: HexNumber;
     last_output_check_block: HexNumber;
+    last_tournament_check_block: HexNumber;
+    foreclose_search_last_block: HexNumber;
     processed_inputs: HexNumber;
     created_at: DateTime;
     updated_at: DateTime;
@@ -92,6 +97,14 @@ export type Application = {
         created_at: DateTime;
         updated_at: DateTime;
     };
+};
+
+export type WithdrawalConfig = {
+    guardian: Address;
+    log2_leaves_per_account: HexNumber;
+    log2_max_num_of_accounts: HexNumber;
+    accounts_drive_start_index: HexNumber;
+    withdrawal_output_builder: Address;
 };
 
 export type GetApplicationReturnType = {
@@ -117,6 +130,7 @@ export type Epoch = {
     claim_transaction_hash: Hash | null;
     tournament_address: Address | null;
     status: EpochStatus;
+    staged_at_block: HexNumber | null;
     virtual_index: HexNumber;
     created_at: DateTime;
     updated_at: DateTime;

--- a/packages/viem/__tests__/converter.test.ts
+++ b/packages/viem/__tests__/converter.test.ts
@@ -1,8 +1,9 @@
-import type { Application, Output } from "@cartesi/rpc";
+import type { Application, Epoch, Output } from "@cartesi/rpc";
 import { getAddress, hexToBigInt } from "viem";
 import { describe, expect, it } from "vitest";
 import {
     applicationConverter,
+    epochConverter,
     outputConverter,
 } from "../src/types/converter.js";
 
@@ -43,9 +44,87 @@ describe("converter", () => {
             last_input_check_block: "0x1f3",
             last_output_check_block: "0x1f3",
             epoch_length: "0x2d0",
+            claim_staging_period: "0x5",
+            foreclose_search_last_block: "0x1f3",
+            last_tournament_check_block: "0x1f3",
+            withdrawal_config: {
+                guardian: "0x0000000000000000000000000000000000000000",
+                log2_leaves_per_account: "0x14",
+                log2_max_num_of_accounts: "0x20",
+                accounts_drive_start_index: "0x0",
+                withdrawal_output_builder:
+                    "0x0000000000000000000000000000000000000000",
+            },
             processed_inputs: "0x0",
         };
+
         const application = applicationConverter(rpcApplication);
+
+        const properties = Object.keys(application);
+        expect(properties).toHaveLength(22);
+        expect(properties).toEqual(
+            expect.arrayContaining([
+                "name",
+                "applicationAddress",
+                "consensusAddress",
+                "inputBoxAddress",
+                "templateHash",
+                "epochLength",
+                "claimStagingPeriod",
+                "withdrawalConfig",
+                "dataAvailability",
+                "consensusType",
+                "state",
+                "inputBoxBlock",
+                "lastEpochCheckBlock",
+                "lastInputCheckBlock",
+                "lastOutputCheckBlock",
+                "lastTournamentCheckBlock",
+                "forecloseSearchLastBlock",
+                "processedInputs",
+                "createdAt",
+                "updatedAt",
+                "executionParameters",
+            ]),
+        );
+
+        const withdrawalConfigProperties = Object.keys(
+            application.withdrawalConfig,
+        );
+        expect(withdrawalConfigProperties).toHaveLength(5);
+        expect(withdrawalConfigProperties).toEqual(
+            expect.arrayContaining([
+                "guardian",
+                "log2LeavesPerAccount",
+                "log2MaxNumOfAccounts",
+                "accountsDriveStartIndex",
+                "withdrawalOutputBuilder",
+            ]),
+        );
+
+        const executionParametersProperties = Object.keys(
+            application.executionParameters,
+        );
+
+        expect(executionParametersProperties).toHaveLength(15);
+        expect(executionParametersProperties).toEqual(
+            expect.arrayContaining([
+                "snapshotPolicy",
+                "advanceIncCycles",
+                "advanceMaxCycles",
+                "inspectIncCycles",
+                "inspectMaxCycles",
+                "advanceIncDeadline",
+                "advanceMaxDeadline",
+                "inspectIncDeadline",
+                "inspectMaxDeadline",
+                "loadDeadline",
+                "storeDeadline",
+                "fastDeadline",
+                "maxConcurrentInspects",
+            ]),
+        );
+
         expect(application).toBeDefined();
         expect(application.applicationAddress).toBe(
             getAddress(rpcApplication.iapplication_address),
@@ -128,7 +207,114 @@ describe("converter", () => {
         expect(application.updatedAt).toStrictEqual(
             new Date(rpcApplication.updated_at),
         );
+
+        expect(application.claimStagingPeriod).toEqual(
+            hexToBigInt(rpcApplication.claim_staging_period),
+        );
+        expect(application.forecloseSearchLastBlock).toEqual(
+            hexToBigInt(rpcApplication.foreclose_search_last_block),
+        );
+        expect(application.lastTournamentCheckBlock).toEqual(
+            hexToBigInt(rpcApplication.last_tournament_check_block),
+        );
+        expect(application.withdrawalConfig).toEqual({
+            guardian: rpcApplication.withdrawal_config.guardian,
+            log2LeavesPerAccount: hexToBigInt(
+                rpcApplication.withdrawal_config.log2_leaves_per_account,
+            ),
+            log2MaxNumOfAccounts: hexToBigInt(
+                rpcApplication.withdrawal_config.log2_max_num_of_accounts,
+            ),
+            accountsDriveStartIndex: hexToBigInt(
+                rpcApplication.withdrawal_config.accounts_drive_start_index,
+            ),
+            withdrawalOutputBuilder:
+                rpcApplication.withdrawal_config.withdrawal_output_builder,
+        });
         expect(application.reason).toBeUndefined();
+    });
+
+    it("should convert the epoch", () => {
+        const rpcEpoch: Epoch = {
+            index: "0x5",
+            first_block: "0x10",
+            last_block: "0x1f3",
+            input_index_lower_bound: "0x0",
+            input_index_upper_bound: "0x5",
+            machine_hash:
+                "0x3b57a86b635d433eb923dc86fa6f9832f15a88f89cfa7d8d45f568dbb6cf992e",
+            outputs_merkle_root:
+                "0x3b57a86b635d433eb923dc86fa6f9832f15a88f89cfa7d8d45f568dbb6cf992e",
+            outputs_merkle_proof: null,
+            tournament_address: "0x67742ff5b2b762503ff0a92738c6fc2ea4a4d182",
+            commitment:
+                "0x3b57a86b635d433eb923dc86fa6f9832f15a88f89cfa7d8d45f568dbb6cf992e",
+            commitment_proof: null,
+            claim_transaction_hash: null,
+            created_at: "2025-04-10T03:23:27.450Z",
+            updated_at: "2025-04-10T04:03:28.755Z",
+            staged_at_block: "0x1f3",
+            status: "OPEN",
+            virtual_index: "0x5",
+        };
+
+        const epoch = epochConverter(rpcEpoch);
+
+        const props = Object.keys(epoch);
+        expect(props).toHaveLength(17);
+        expect(props).toEqual(
+            expect.arrayContaining([
+                "index",
+                "firstBlock",
+                "lastBlock",
+                "inputIndexLowerBound",
+                "inputIndexUpperBound",
+                "machineHash",
+                "outputsMerkleRoot",
+                "outputsMerkleProof",
+                "tournamentAddress",
+                "commitment",
+                "commitmentProof",
+                "claimTransactionHash",
+                "createdAt",
+                "updatedAt",
+                "stagedAtBlock",
+                "status",
+                "virtualIndex",
+            ]),
+        );
+
+        expect(epoch.index).toEqual(hexToBigInt(rpcEpoch.index));
+        expect(epoch.firstBlock).toEqual(hexToBigInt(rpcEpoch.first_block));
+        expect(epoch.lastBlock).toEqual(hexToBigInt(rpcEpoch.last_block));
+        expect(epoch.inputIndexLowerBound).toEqual(
+            hexToBigInt(rpcEpoch.input_index_lower_bound),
+        );
+        expect(epoch.inputIndexUpperBound).toEqual(
+            hexToBigInt(rpcEpoch.input_index_upper_bound),
+        );
+        expect(epoch.machineHash).toEqual(rpcEpoch.machine_hash);
+        expect(epoch.outputsMerkleRoot).toEqual(rpcEpoch.outputs_merkle_root);
+        expect(epoch.outputsMerkleProof).toEqual(rpcEpoch.outputs_merkle_proof);
+        expect(epoch.tournamentAddress).toEqual(
+            rpcEpoch.tournament_address
+                ? getAddress(rpcEpoch.tournament_address)
+                : null,
+        );
+        expect(epoch.commitment).toEqual(rpcEpoch.commitment);
+        expect(epoch.commitmentProof).toEqual(rpcEpoch.commitment_proof);
+        expect(epoch.claimTransactionHash).toEqual(
+            rpcEpoch.claim_transaction_hash,
+        );
+        expect(epoch.status).toEqual(rpcEpoch.status);
+        expect(epoch.stagedAtBlock).toEqual(
+            rpcEpoch.staged_at_block
+                ? hexToBigInt(rpcEpoch.staged_at_block)
+                : null,
+        );
+        expect(epoch.virtualIndex).toEqual(hexToBigInt(rpcEpoch.virtual_index));
+        expect(epoch.createdAt).toStrictEqual(new Date(rpcEpoch.created_at));
+        expect(epoch.updatedAt).toStrictEqual(new Date(rpcEpoch.updated_at));
     });
 
     it("should convert the output", () => {

--- a/packages/viem/__tests__/converter.test.ts
+++ b/packages/viem/__tests__/converter.test.ts
@@ -1,10 +1,11 @@
-import type { Application, Epoch, Output } from "@cartesi/rpc";
+import type { Application, Epoch, Output, Withdrawal } from "@cartesi/rpc";
 import { getAddress, hexToBigInt } from "viem";
 import { describe, expect, it } from "vitest";
 import {
     applicationConverter,
     epochConverter,
     outputConverter,
+    withdrawalConverter,
 } from "../src/types/converter.js";
 
 describe("converter", () => {
@@ -19,7 +20,8 @@ describe("converter", () => {
             data_availability:
                 "0xb12c9ede0000000000000000000000001b51e2992a2755ba4d6f7094032df91991a0cfac",
             consensus_type: "AUTHORITY",
-            state: "ENABLED",
+            status: "OK",
+            enabled: true,
             created_at: "2025-04-10T03:23:27.450183Z",
             updated_at: "2025-04-10T04:03:28.755635Z",
             execution_parameters: {
@@ -45,8 +47,18 @@ describe("converter", () => {
             last_output_check_block: "0x1f3",
             epoch_length: "0x2d0",
             claim_staging_period: "0x5",
-            foreclose_search_last_block: "0x1f3",
             last_tournament_check_block: "0x1f3",
+            last_accounts_drive_proved_check_block: "0x0",
+            last_foreclose_check_block: "0x0",
+            last_withdrawal_check_block: "0x0",
+            foreclose_block: "0x0",
+            foreclose_transaction:
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            accounts_drive_proved_block: "0x0",
+            accounts_drive_proved_transaction:
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            accounts_drive_merkle_root:
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
             withdrawal_config: {
                 guardian: "0x0000000000000000000000000000000000000000",
                 log2_leaves_per_account: "0x14",
@@ -61,31 +73,40 @@ describe("converter", () => {
         const application = applicationConverter(rpcApplication);
 
         const properties = Object.keys(application);
-        expect(properties).toHaveLength(22);
-        expect(properties).toEqual(
-            expect.arrayContaining([
+        expect(properties).toHaveLength(30);
+        expect(properties.sort()).toEqual(
+            [
                 "name",
                 "applicationAddress",
                 "consensusAddress",
                 "inputBoxAddress",
+                "lastForecloseCheckBlock",
+                "lastAccountsDriveProvedCheckBlock",
+                "lastWithdrawalCheckBlock",
+                "forecloseBlock",
+                "forecloseTransaction",
+                "accountsDriveProvedBlock",
+                "accountsDriveProvedTransaction",
+                "accountsDriveMerkleRoot",
                 "templateHash",
                 "epochLength",
                 "claimStagingPeriod",
                 "withdrawalConfig",
                 "dataAvailability",
                 "consensusType",
-                "state",
+                "status",
+                "enabled",
+                "reason",
                 "inputBoxBlock",
                 "lastEpochCheckBlock",
                 "lastInputCheckBlock",
                 "lastOutputCheckBlock",
                 "lastTournamentCheckBlock",
-                "forecloseSearchLastBlock",
                 "processedInputs",
                 "createdAt",
                 "updatedAt",
                 "executionParameters",
-            ]),
+            ].sort(),
         );
 
         const withdrawalConfigProperties = Object.keys(
@@ -151,7 +172,7 @@ describe("converter", () => {
         expect(application.processedInputs).toBe(
             hexToBigInt(rpcApplication.processed_inputs),
         );
-        expect(application.state).toBe(rpcApplication.state);
+        expect(application.status).toBe(rpcApplication.status);
         expect(application.templateHash).toBe(rpcApplication.template_hash);
         expect(application.executionParameters).toBeDefined();
         expect(application.executionParameters.advanceIncCycles).toBe(
@@ -211,8 +232,29 @@ describe("converter", () => {
         expect(application.claimStagingPeriod).toEqual(
             hexToBigInt(rpcApplication.claim_staging_period),
         );
-        expect(application.forecloseSearchLastBlock).toEqual(
-            hexToBigInt(rpcApplication.foreclose_search_last_block),
+        expect(application.lastForecloseCheckBlock).toEqual(
+            hexToBigInt(rpcApplication.last_foreclose_check_block),
+        );
+        expect(application.lastAccountsDriveProvedCheckBlock).toEqual(
+            hexToBigInt(rpcApplication.last_accounts_drive_proved_check_block),
+        );
+        expect(application.lastWithdrawalCheckBlock).toEqual(
+            hexToBigInt(rpcApplication.last_withdrawal_check_block),
+        );
+        expect(application.forecloseBlock).toEqual(
+            hexToBigInt(rpcApplication.foreclose_block),
+        );
+        expect(application.forecloseTransaction).toEqual(
+            rpcApplication.foreclose_transaction,
+        );
+        expect(application.accountsDriveProvedBlock).toEqual(
+            hexToBigInt(rpcApplication.accounts_drive_proved_block),
+        );
+        expect(application.accountsDriveProvedTransaction).toEqual(
+            rpcApplication.accounts_drive_proved_transaction,
+        );
+        expect(application.accountsDriveMerkleRoot).toEqual(
+            rpcApplication.accounts_drive_merkle_root,
         );
         expect(application.lastTournamentCheckBlock).toEqual(
             hexToBigInt(rpcApplication.last_tournament_check_block),
@@ -416,6 +458,54 @@ describe("converter", () => {
         expect(output.decodedData?.type).toBe(rpcOutput.decoded_data?.type);
         expect(output.decodedData?.payload).toBe(
             rpcOutput.decoded_data?.payload,
+        );
+    });
+
+    it("should convert the withdrawal", () => {
+        const rpcWithdrawal: Withdrawal = {
+            account_index: "0x2a",
+            account: "0xAbCdef1234567890aBCDEf1234567890abCDef12",
+            output: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            block_number: "0x1f4",
+            transaction_hash:
+                "0x8f2c9ab4d7e15c30b6f18a4ee2d9037c4a1f5d2e9b7c63a0d4e8f1b25c7a9d3e",
+            log_index: "0x3",
+            created_at: "2025-04-11T10:00:00.000Z",
+            updated_at: "2025-04-11T10:05:00.000Z",
+        };
+
+        const withdrawal = withdrawalConverter(rpcWithdrawal);
+
+        const props = Object.keys(withdrawal);
+        expect(props).toHaveLength(8);
+        expect(props).toEqual(
+            expect.arrayContaining([
+                "accountIndex",
+                "account",
+                "output",
+                "blockNumber",
+                "transactionHash",
+                "logIndex",
+                "createdAt",
+                "updatedAt",
+            ]),
+        );
+
+        expect(withdrawal.accountIndex).toBe(
+            hexToBigInt(rpcWithdrawal.account_index),
+        );
+        expect(withdrawal.account).toBe(rpcWithdrawal.account);
+        expect(withdrawal.output).toBe(rpcWithdrawal.output);
+        expect(withdrawal.blockNumber).toBe(
+            hexToBigInt(rpcWithdrawal.block_number),
+        );
+        expect(withdrawal.transactionHash).toBe(rpcWithdrawal.transaction_hash);
+        expect(withdrawal.logIndex).toBe(hexToBigInt(rpcWithdrawal.log_index));
+        expect(withdrawal.createdAt).toStrictEqual(
+            new Date(rpcWithdrawal.created_at),
+        );
+        expect(withdrawal.updatedAt).toStrictEqual(
+            new Date(rpcWithdrawal.updated_at),
         );
     });
 });

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -15,12 +15,13 @@
         "@biomejs/biome": "catalog:",
         "@rollups-ts/utils": "workspace:*",
         "@types/node": "catalog:",
+        "@vitest/coverage-v8": "^4.1.7",
         "@wagmi/cli": "^2.10.0",
         "npm-run-all": "^4.1.5",
         "ts-node": "^10.9.2",
         "tsup": "catalog:",
         "typescript": "catalog:",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.7"
     },
     "type": "module",
     "main": "./dist/index.cjs",
@@ -87,6 +88,7 @@
         "download:rollups-contracts": "ts-node ./scripts/getRollupsContracts.ts",
         "lint": "biome check",
         "prepack": "run-s build",
-        "test": "vitest"
+        "test": "vitest",
+        "test:coverage": "vitest run --coverage"
     }
 }

--- a/packages/viem/src/actions/getWithdrawal.ts
+++ b/packages/viem/src/actions/getWithdrawal.ts
@@ -1,0 +1,22 @@
+import { type Client, type Transport, numberToHex } from "viem";
+import type { PublicCartesiRpcSchema } from "../decorators/publicL2.js";
+import type {
+    GetWithdrawalParams,
+    GetWithdrawalReturnType,
+} from "../types/actions.js";
+import { withdrawalConverter } from "../types/converter.js";
+
+export const getWithdrawal = async (
+    client: Client<Transport, undefined, undefined, PublicCartesiRpcSchema>,
+    params: GetWithdrawalParams,
+): Promise<GetWithdrawalReturnType> => {
+    const { data: withdrawal } = await client.request({
+        method: "cartesi_getWithdrawal",
+        params: {
+            application: params.application,
+            account_index: numberToHex(params.accountIndex),
+        },
+    });
+
+    return withdrawalConverter(withdrawal);
+};

--- a/packages/viem/src/actions/index.ts
+++ b/packages/viem/src/actions/index.ts
@@ -81,6 +81,7 @@ export { getOutput } from "./getOutput.js";
 export { getProcessedInputCount } from "./getProcessedInputCount.js";
 export { getReport } from "./getReport.js";
 export { getTournament } from "./getTournament.js";
+export { getWithdrawal } from "./getWithdrawal.js";
 export { listApplications } from "./listApplications.js";
 export { listCommitments } from "./listCommitments.js";
 export { listEpochs } from "./listEpochs.js";
@@ -90,6 +91,7 @@ export { listMatches } from "./listMatches.js";
 export { listOutputs } from "./listOutputs.js";
 export { listReports } from "./listReports.js";
 export { listTournaments } from "./listTournaments.js";
+export { listWithdrawals } from "./listWithdrawals.js";
 export {
     validateOutput,
     type ValidateOutputParameters,

--- a/packages/viem/src/actions/listWithdrawals.ts
+++ b/packages/viem/src/actions/listWithdrawals.ts
@@ -1,0 +1,33 @@
+import { type Client, type Transport, numberToHex } from "viem";
+import type { PublicCartesiRpcSchema } from "../decorators/publicL2.js";
+import type {
+    ListWithdrawalsParams,
+    ListWithdrawalsReturnType,
+} from "../types/actions.js";
+import {
+    paginationConverter,
+    withdrawalConverter,
+} from "../types/converter.js";
+
+export const listWithdrawals = async (
+    client: Client<Transport, undefined, undefined, PublicCartesiRpcSchema>,
+    params: ListWithdrawalsParams,
+): Promise<ListWithdrawalsReturnType> => {
+    const withdrawals = await client.request({
+        method: "cartesi_listWithdrawals",
+        params: {
+            application: params.application,
+            account_index:
+                params.accountIndex !== undefined
+                    ? numberToHex(params.accountIndex)
+                    : undefined,
+            limit: params.limit,
+            offset: params.offset,
+            descending: params.descending,
+        },
+    });
+    return {
+        data: withdrawals.data.map(withdrawalConverter),
+        pagination: paginationConverter(withdrawals.pagination),
+    };
+};

--- a/packages/viem/src/decorators/publicL2.ts
+++ b/packages/viem/src/decorators/publicL2.ts
@@ -23,6 +23,8 @@ import type {
     GetReportReturnType as GetReportReturnTypeRpc,
     GetTournamentParams as GetTournamentParamsRpc,
     GetTournamentReturnType as GetTournamentReturnTypeRpc,
+    GetWithdrawalParams as GetWithdrawalParamsRpc,
+    GetWithdrawalReturnType as GetWithdrawalReturnTypeRpc,
     ListApplicationsParams as ListApplicationsParamsRpc,
     ListApplicationsReturnType as ListApplicationsReturnTypeRpc,
     ListCommitmentsParams as ListCommitmentsParamsRpc,
@@ -41,6 +43,8 @@ import type {
     ListReportsReturnType as ListReportsReturnTypeRpc,
     ListTournamentsParams as ListTournamentsParamsRpc,
     ListTournamentsReturnType as ListTournamentsReturnTypeRpc,
+    ListWithdrawalsParams as ListWithdrawalsParamsRpc,
+    ListWithdrawalsReturnType as ListWithdrawalsReturnTypeRpc,
 } from "@cartesi/rpc";
 import type { Client, Transport } from "viem";
 
@@ -58,6 +62,7 @@ import {
     getProcessedInputCount,
     getReport,
     getTournament,
+    getWithdrawal,
     listApplications,
     listCommitments,
     listEpochs,
@@ -67,6 +72,7 @@ import {
     listOutputs,
     listReports,
     listTournaments,
+    listWithdrawals,
     waitForInput,
 } from "../actions/index.js";
 import type {
@@ -94,6 +100,8 @@ import type {
     GetReportReturnType,
     GetTournamentParams,
     GetTournamentReturnType,
+    GetWithdrawalParams,
+    GetWithdrawalReturnType,
     ListApplicationsParams,
     ListApplicationsReturnType,
     ListCommitmentsParams,
@@ -112,6 +120,8 @@ import type {
     ListReportsReturnType,
     ListTournamentsParams,
     ListTournamentsReturnType,
+    ListWithdrawalsParams,
+    ListWithdrawalsReturnType,
     WaitForInputParams,
     WaitForInputReturnType,
 } from "../types/actions.js";
@@ -225,6 +235,16 @@ export type PublicCartesiRpcSchema = [
         Method: "cartesi_getNodeVersion";
         ReturnType: GetNodeVersionReturnTypeRpc;
     },
+    {
+        Method: "cartesi_getWithdrawal";
+        Parameters: GetWithdrawalParamsRpc;
+        ReturnType: GetWithdrawalReturnTypeRpc;
+    },
+    {
+        Method: "cartesi_listWithdrawals";
+        Parameters: ListWithdrawalsParamsRpc;
+        ReturnType: ListWithdrawalsReturnTypeRpc;
+    },
 ];
 
 export type PublicActionsL2 = {
@@ -245,7 +265,9 @@ export type PublicActionsL2 = {
     listInputs: (params: ListInputsParams) => Promise<ListInputsReturnType>;
     listOutputs: (params: ListOutputsParams) => Promise<ListOutputsReturnType>;
     listReports: (params: ListReportsParams) => Promise<ListReportsReturnType>;
-
+    listWithdrawals: (
+        params: ListWithdrawalsParams,
+    ) => Promise<ListWithdrawalsReturnType>;
     getApplication: (
         params: GetApplicationParams,
     ) => Promise<GetApplicationReturnType>;
@@ -265,6 +287,9 @@ export type PublicActionsL2 = {
     getInput: (params: GetInputParams) => Promise<GetInputReturnType>;
     getOutput: (params: GetOutputParams) => Promise<GetOutputReturnType>;
     getReport: (params: GetReportParams) => Promise<GetReportReturnType>;
+    getWithdrawal: (
+        params: GetWithdrawalParams,
+    ) => Promise<GetWithdrawalReturnType>;
 
     getProcessedInputCount: (
         params: GetProcessedInputCountParams,
@@ -312,4 +337,6 @@ export const publicActionsL2 =
         getLastAcceptedEpochIndex: (params) =>
             getLastAcceptedEpochIndex(client, params),
         waitForInput: (params) => waitForInput(client, params),
+        getWithdrawal: (params) => getWithdrawal(client, params),
+        listWithdrawals: (params) => listWithdrawals(client, params),
     });

--- a/packages/viem/src/types/actions.ts
+++ b/packages/viem/src/types/actions.ts
@@ -9,6 +9,8 @@ import type {
 } from "@cartesi/rpc";
 import type { ExtractAbiFunctionNames } from "abitype";
 import type { Address, Hash, Hex } from "viem";
+import type { outputsAbi } from "../rollups";
+
 export type {
     ApplicationState,
     ConsensusType,
@@ -17,9 +19,7 @@ export type {
     InputStatus,
     SnapshotPolicy,
     WinnerCommitment,
-} from "@cartesi/rpc";
-
-import type { outputsAbi } from "../rollups";
+};
 
 export type PaginationParams = {
     limit?: number;
@@ -58,6 +58,14 @@ export type Application = {
     inputBoxAddress: Address;
     templateHash: Hash;
     epochLength: bigint;
+    claimStagingPeriod: bigint;
+    withdrawalConfig: {
+        guardian: Address;
+        log2LeavesPerAccount: bigint;
+        log2MaxNumOfAccounts: bigint;
+        accountsDriveStartIndex: bigint;
+        withdrawalOutputBuilder: Address;
+    };
     dataAvailability: DataAvailability;
     consensusType: ConsensusType;
     state: ApplicationState;
@@ -66,6 +74,8 @@ export type Application = {
     lastEpochCheckBlock: bigint;
     lastInputCheckBlock: bigint;
     lastOutputCheckBlock: bigint;
+    lastTournamentCheckBlock: bigint;
+    forecloseSearchLastBlock: bigint;
     processedInputs: bigint;
     createdAt: Date;
     updatedAt: Date;
@@ -112,6 +122,7 @@ export type Epoch = {
     commitmentProof: Hash[] | null;
     claimTransactionHash: Hash | null;
     status: EpochStatus;
+    stagedAtBlock: bigint | null;
     virtualIndex: bigint;
     createdAt: Date;
     updatedAt: Date;

--- a/packages/viem/src/types/actions.ts
+++ b/packages/viem/src/types/actions.ts
@@ -1,5 +1,5 @@
 import type {
-    ApplicationState,
+    ApplicationStatus,
     ConsensusType,
     DeletionReason,
     EpochStatus,
@@ -12,7 +12,7 @@ import type { Address, Hash, Hex } from "viem";
 import type { outputsAbi } from "../rollups";
 
 export type {
-    ApplicationState,
+    ApplicationStatus,
     ConsensusType,
     DeletionReason,
     EpochStatus,
@@ -68,15 +68,23 @@ export type Application = {
     };
     dataAvailability: DataAvailability;
     consensusType: ConsensusType;
-    state: ApplicationState;
+    status: ApplicationStatus;
+    enabled: boolean;
     reason?: string | null;
     inputBoxBlock: bigint;
     lastEpochCheckBlock: bigint;
     lastInputCheckBlock: bigint;
     lastOutputCheckBlock: bigint;
     lastTournamentCheckBlock: bigint;
-    forecloseSearchLastBlock: bigint;
+    lastForecloseCheckBlock: bigint;
+    lastAccountsDriveProvedCheckBlock: bigint;
+    lastWithdrawalCheckBlock: bigint;
     processedInputs: bigint;
+    forecloseBlock: bigint;
+    forecloseTransaction: Hash;
+    accountsDriveProvedBlock: bigint;
+    accountsDriveProvedTransaction: Hash;
+    accountsDriveMerkleRoot: Hash;
     createdAt: Date;
     updatedAt: Date;
     executionParameters: {
@@ -419,3 +427,31 @@ export type WaitForInputParams = GetInputParams & {
 };
 
 export type WaitForInputReturnType = Input;
+
+export type Withdrawal = {
+    accountIndex: bigint;
+    account: Hex;
+    output: Hex;
+    blockNumber: bigint;
+    transactionHash: Hash;
+    logIndex: bigint;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type ListWithdrawalsParams = PaginationParams & {
+    application: string | Address;
+    accountIndex?: bigint;
+};
+
+export type ListWithdrawalsReturnType = {
+    data: Withdrawal[];
+    pagination: Pagination;
+};
+
+export type GetWithdrawalParams = {
+    application: string | Address;
+    accountIndex: bigint;
+};
+
+export type GetWithdrawalReturnType = Withdrawal;

--- a/packages/viem/src/types/converter.ts
+++ b/packages/viem/src/types/converter.ts
@@ -75,6 +75,22 @@ export const applicationConverter = (
         inputBoxAddress: getAddress(application.iinputbox_address),
         templateHash: application.template_hash,
         epochLength: hexToBigInt(application.epoch_length),
+        claimStagingPeriod: hexToBigInt(application.claim_staging_period),
+        withdrawalConfig: {
+            guardian: getAddress(application.withdrawal_config.guardian),
+            log2LeavesPerAccount: hexToBigInt(
+                application.withdrawal_config.log2_leaves_per_account,
+            ),
+            log2MaxNumOfAccounts: hexToBigInt(
+                application.withdrawal_config.log2_max_num_of_accounts,
+            ),
+            accountsDriveStartIndex: hexToBigInt(
+                application.withdrawal_config.accounts_drive_start_index,
+            ),
+            withdrawalOutputBuilder: getAddress(
+                application.withdrawal_config.withdrawal_output_builder,
+            ),
+        },
         dataAvailability: parseDataAvailability(application.data_availability),
         consensusType: application.consensus_type,
         state: application.state,
@@ -83,6 +99,12 @@ export const applicationConverter = (
         lastEpochCheckBlock: hexToBigInt(application.last_epoch_check_block),
         lastInputCheckBlock: hexToBigInt(application.last_input_check_block),
         lastOutputCheckBlock: hexToBigInt(application.last_output_check_block),
+        lastTournamentCheckBlock: hexToBigInt(
+            application.last_tournament_check_block,
+        ),
+        forecloseSearchLastBlock: hexToBigInt(
+            application.foreclose_search_last_block,
+        ),
         processedInputs: hexToBigInt(application.processed_inputs),
         createdAt: new Date(application.created_at),
         updatedAt: new Date(application.updated_at),
@@ -146,6 +168,9 @@ export const epochConverter = (epoch: EpochRpc): Epoch => {
         commitmentProof: epoch.commitment_proof,
         claimTransactionHash: epoch.claim_transaction_hash,
         status: epoch.status,
+        stagedAtBlock: epoch.staged_at_block
+            ? hexToBigInt(epoch.staged_at_block)
+            : null,
         virtualIndex: hexToBigInt(epoch.virtual_index),
         createdAt: new Date(epoch.created_at),
         updatedAt: new Date(epoch.updated_at),

--- a/packages/viem/src/types/converter.ts
+++ b/packages/viem/src/types/converter.ts
@@ -12,6 +12,7 @@ import type {
     Report as ReportRpc,
     Tournament as TournamentRpc,
     Voucher as VoucherRpc,
+    Withdrawal as WithdrawalRpc,
 } from "@cartesi/rpc";
 import { type Hex, decodeFunctionData, getAddress, hexToBigInt } from "viem";
 import { dataAvailabilityAbi } from "../rollups.js";
@@ -30,6 +31,7 @@ import type {
     Report,
     Tournament,
     Voucher,
+    Withdrawal,
 } from "./actions.js";
 
 export const paginationConverter = (pagination: PaginationRpc): Pagination => {
@@ -93,7 +95,8 @@ export const applicationConverter = (
         },
         dataAvailability: parseDataAvailability(application.data_availability),
         consensusType: application.consensus_type,
-        state: application.state,
+        status: application.status,
+        enabled: application.enabled,
         reason: application.reason,
         inputBoxBlock: hexToBigInt(application.iinputbox_block),
         lastEpochCheckBlock: hexToBigInt(application.last_epoch_check_block),
@@ -102,10 +105,24 @@ export const applicationConverter = (
         lastTournamentCheckBlock: hexToBigInt(
             application.last_tournament_check_block,
         ),
-        forecloseSearchLastBlock: hexToBigInt(
-            application.foreclose_search_last_block,
+        lastForecloseCheckBlock: hexToBigInt(
+            application.last_foreclose_check_block,
+        ),
+        lastAccountsDriveProvedCheckBlock: hexToBigInt(
+            application.last_accounts_drive_proved_check_block,
+        ),
+        lastWithdrawalCheckBlock: hexToBigInt(
+            application.last_withdrawal_check_block,
         ),
         processedInputs: hexToBigInt(application.processed_inputs),
+        forecloseBlock: hexToBigInt(application.foreclose_block),
+        forecloseTransaction: application.foreclose_transaction,
+        accountsDriveProvedBlock: hexToBigInt(
+            application.accounts_drive_proved_block,
+        ),
+        accountsDriveProvedTransaction:
+            application.accounts_drive_proved_transaction,
+        accountsDriveMerkleRoot: application.accounts_drive_merkle_root,
         createdAt: new Date(application.created_at),
         updatedAt: new Date(application.updated_at),
         executionParameters: {
@@ -335,5 +352,18 @@ export const reportConverter = (report: ReportRpc): Report => {
         rawData: report.raw_data,
         createdAt: new Date(report.created_at),
         updatedAt: new Date(report.updated_at),
+    };
+};
+
+export const withdrawalConverter = (withdrawal: WithdrawalRpc): Withdrawal => {
+    return {
+        accountIndex: hexToBigInt(withdrawal.account_index),
+        account: withdrawal.account,
+        output: withdrawal.output,
+        blockNumber: hexToBigInt(withdrawal.block_number),
+        transactionHash: withdrawal.transaction_hash,
+        logIndex: hexToBigInt(withdrawal.log_index),
+        createdAt: new Date(withdrawal.created_at),
+        updatedAt: new Date(withdrawal.updated_at),
     };
 };

--- a/packages/viem/vitest.config.ts
+++ b/packages/viem/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        dir: "./__tests__",
+        exclude: ["node_modules/**"],
+        environment: "node",
+        globals: true,
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "lcov"],
+            exclude: ["./src/rollups.ts"],
+            include: ["**/src"],
+        },
+    },
+});

--- a/packages/wagmi/src/publicL2/index.ts
+++ b/packages/wagmi/src/publicL2/index.ts
@@ -22,3 +22,5 @@ export { useReports } from "./useReports.js";
 export { useTournament } from "./useTournament.js";
 export { useTournaments } from "./useTournaments.js";
 export { useWaitForInput } from "./useWaitForInput.js";
+export { useWithdrawal } from "./useWithdrawal.js";
+export { useWithdrawals } from "./useWithdrawals.js";

--- a/packages/wagmi/src/publicL2/useWithdrawal.ts
+++ b/packages/wagmi/src/publicL2/useWithdrawal.ts
@@ -1,0 +1,37 @@
+import type { CartesiPublicClient, GetWithdrawalParams } from "@cartesi/viem";
+import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
+import { useCartesiClient } from "./provider.js";
+
+const withdrawalOptions = (
+    client: CartesiPublicClient,
+    params: Partial<GetWithdrawalParams>,
+) =>
+    queryOptions({
+        queryKey: [
+            "withdrawal",
+            {
+                application: params.application,
+                accountIndex: params.accountIndex?.toString(),
+            },
+        ],
+        queryFn:
+            params.application !== undefined &&
+            params.accountIndex !== undefined
+                ? () =>
+                      client.getWithdrawal({
+                          application: params.application as string,
+                          accountIndex: params.accountIndex as bigint,
+                      })
+                : skipToken,
+    });
+
+export const useWithdrawal = (
+    params: Partial<GetWithdrawalParams> &
+        Omit<ReturnType<typeof withdrawalOptions>, "queryKey" | "queryFn">,
+) => {
+    const client = useCartesiClient();
+    return useQuery({
+        ...params,
+        ...withdrawalOptions(client, params),
+    });
+};

--- a/packages/wagmi/src/publicL2/useWithdrawals.ts
+++ b/packages/wagmi/src/publicL2/useWithdrawals.ts
@@ -1,0 +1,42 @@
+import type { CartesiPublicClient, ListWithdrawalsParams } from "@cartesi/viem";
+import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
+import { useCartesiClient } from "./provider.js";
+
+const withdrawalsOptions = (
+    client: CartesiPublicClient,
+    params: Partial<ListWithdrawalsParams>,
+) =>
+    queryOptions({
+        queryKey: [
+            "withdrawals",
+            {
+                application: params.application,
+                accountIndex: params.accountIndex?.toString(),
+                limit: params.limit,
+                offset: params.offset,
+                descending: params.descending,
+            },
+        ],
+        queryFn:
+            params.application !== undefined
+                ? () =>
+                      client.listWithdrawals({
+                          application: params.application as string,
+                          accountIndex: params.accountIndex,
+                          limit: params.limit,
+                          offset: params.offset,
+                          descending: params.descending,
+                      })
+                : skipToken,
+    });
+
+export const useWithdrawals = (
+    params: Partial<ListWithdrawalsParams> &
+        Omit<ReturnType<typeof withdrawalsOptions>, "queryKey" | "queryFn">,
+) => {
+    const client = useCartesiClient();
+    return useQuery({
+        ...params,
+        ...withdrawalsOptions(client, params),
+    });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
       '@wagmi/cli':
         specifier: ^2.10.0
         version: 2.10.0(typescript@5.9.3)
@@ -172,8 +175,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.5.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
 
   packages/wagmi:
     dependencies:
@@ -288,6 +291,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
@@ -321,6 +329,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.7':
     resolution: {integrity: sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==}
@@ -2126,34 +2138,43 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@wagmi/cli@2.10.0':
     resolution: {integrity: sha512-2tYt6Bp1q26mWexH+XE6dMpPB5/Gp/3OVtE2SeeJ/gNHKLZmVF/TuoZR75mpJKTpofyvpz/fnuMCkUxzbc/kRw==}
@@ -2282,6 +2303,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -3093,6 +3117,10 @@ packages:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -3172,6 +3200,9 @@ packages:
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3374,6 +3405,18 @@ packages:
     peerDependencies:
       ws: '*'
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
@@ -3384,6 +3427,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3553,6 +3599,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -4551,6 +4604,10 @@ packages:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4899,21 +4956,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4926,6 +4985,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -5150,6 +5213,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -5189,6 +5256,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.7':
     optionalDependencies:
@@ -6991,44 +7060,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.0':
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.5.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.7(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
-  '@vitest/pretty-format@4.1.0':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
+  '@vitest/spy@4.1.7': {}
 
-  '@vitest/utils@4.1.0':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -7138,6 +7221,12 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -8064,6 +8153,8 @@ snapshots:
 
   has-flag@3.0.0: {}
 
+  has-flag@4.0.0: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -8243,6 +8334,8 @@ snapshots:
   hono@4.12.8: {}
 
   hosted-git-info@2.8.9: {}
+
+  html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
 
@@ -8429,11 +8522,26 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   javascript-stringify@2.1.0: {}
 
   jiti@2.6.1: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -8572,6 +8680,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -10044,6 +10162,10 @@ snapshots:
     dependencies:
       has-flag: 3.0.0
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tabbable@6.4.0: {}
@@ -10412,15 +10534,15 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.2
 
-  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vitest@4.1.7(@types/node@25.5.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10436,6 +10558,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
# Summary
Code changes to update the RPC package with changes in the rollups-node JSON-RPC API. 


#### Reference

<details>
<summary>Git diff file</summary>

```diff
diff --git a/internal/jsonrpc/jsonrpc-discover.json b/internal/jsonrpc/jsonrpc-discover.json
index 3697c495..bd26c737 100644
--- a/internal/jsonrpc/jsonrpc-discover.json
+++ b/internal/jsonrpc/jsonrpc-discover.json
@@ -1020,6 +1020,12 @@
                                        "epoch_length": {
                                                "$ref": "#/components/schemas/UnsignedInteger"
                                        },
+                                       "claim_staging_period": {
+                                               "$ref": "#/components/schemas/UnsignedInteger"
+                                       },
+                                       "withdrawal_config": {
+                                               "$ref": "#/components/schemas/WithdrawalConfig"
+                                       },
                                        "data_availability": {
                                                "$ref": "#/components/schemas/ByteArray"
                                        },
@@ -1048,6 +1054,9 @@
                                        "last_tournament_check_block": {
                                                "$ref": "#/components/schemas/UnsignedInteger"
                                        },
+                                       "foreclose_search_last_block": {
+                                               "$ref": "#/components/schemas/UnsignedInteger"
+                                       },
                                        "processed_inputs": {
                                                "$ref": "#/components/schemas/UnsignedInteger"
                                        },
@@ -1094,6 +1103,7 @@
                                        "INPUTS_PROCESSED",
                                        "CLAIM_COMPUTED",
                                        "CLAIM_SUBMITTED",
+                                       "CLAIM_STAGED",
                                        "CLAIM_ACCEPTED",
                                        "CLAIM_REJECTED"
                                ]
@@ -1146,6 +1156,9 @@
                                        "status": {
                                                "$ref": "#/components/schemas/EpochStatus"
                                        },
+                                       "staged_at_block": {
+                                               "oneOf": [{"$ref": "#/components/schemas/UnsignedInteger"}, {"type": "null"}]
+                                       },
                                        "virtual_index": {
                                                "$ref": "#/components/schemas/UnsignedInteger"
                                        },
@@ -1573,6 +1586,34 @@
                                "format": "hex-byte",
                                "pattern": "^0x[a-fA-F0-9]{40}$"
                        },
+                       "WithdrawalConfig": {
+                               "type": "object",
+                               "description": "On-chain WithdrawalConfig mirroring the five Application contract immutables (guardian, log2_leaves_per_account, log2_max_num_of_accounts, accounts_drive_start_index, withdrawal_output_builder). The all-zero shape encodes the no-foreclosure default.",
+                               "properties": {
+                                       "guardian": {
+                                               "$ref": "#/components/schemas/EthereumAddress"
+                                       },
+                                       "log2_leaves_per_account": {
+                                               "$ref": "#/components/schemas/UnsignedInteger"
+                                       },
+                                       "log2_max_num_of_accounts": {
+                                               "$ref": "#/components/schemas/UnsignedInteger"
+                                       },
+                                       "accounts_drive_start_index": {
+                                               "$ref": "#/components/schemas/UnsignedInteger"
+                                       },
+                                       "withdrawal_output_builder": {
+                                               "$ref": "#/components/schemas/EthereumAddress"
+                                       }
+                               },
+                               "required": [
+                                       "guardian",
+                                       "log2_leaves_per_account",
+                                       "log2_max_num_of_accounts",
+                                       "accounts_drive_start_index",
+                                       "withdrawal_output_builder"
+                               ]
+                       },
                        "Hash": {
                                "type": "string",
                                "format": "hex-byte",
```
</details>

### Updated Reference 

* https://github.com/cartesi/rollups-node/pull/779
