### PR TITLE
fix(rpc): propagate transport failures to pending requests

### DIFF
--- a/.changeset/tidy-lions-report.md
+++ b/.changeset/tidy-lions-report.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rpc": patch
+---
+
+propagate transport failures (network errors, non-200 responses, invalid JSON) to pending requests instead of hanging forever

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -19,7 +19,9 @@ export const createClient = (options: ClientOptions): CartesiClient => {
             headers.authorization = `Bearer ${token}`;
         }
 
-        fetch(uri, {
+        // return the promise so JSONRPCClient rejects the pending request
+        // when the transport fails (network error, non-200, invalid JSON)
+        return fetch(uri, {
             method: "POST",
             headers,
             body: JSON.stringify(jsonRPCRequest),
@@ -30,7 +32,9 @@ export const createClient = (options: ClientOptions): CartesiClient => {
                     .then((jsonRPCResponse) => client.receive(jsonRPCResponse));
             }
             if (jsonRPCRequest.id !== undefined) {
-                return Promise.reject(new Error(response.statusText));
+                return Promise.reject(
+                    new Error(response.statusText || `HTTP ${response.status}`),
+                );
             }
         });
     });


### PR DESCRIPTION
## Problem

The send function `createClient` passes to `JSONRPCClient` never returned the `fetch` promise chain. `json-rpc-2.0` only fails a pending request when the promise returned by the send function rejects, so every transport failure left the caller's `client.request(...)` promise pending **forever**, surfacing only as an unhandled promise rejection:

1. Network failure (fetch rejects, e.g. connection refused)
2. Non-200 HTTP response (the inner `Promise.reject(new Error(response.statusText))` had nothing consuming it)
3. HTTP 200 with an invalid JSON body (`response.json()` rejects)

## Fix

- Return the fetch promise chain from the send function, matching the documented `json-rpc-2.0` usage, so all three failure modes reject the pending request with the underlying error.
- Fall back to `HTTP ${status}` in the error message when `statusText` is empty (it always is over HTTP/2).

## Verification

Reproduced all three failure modes against the built package: before the fix each one hung past a 1.5s timeout with an unhandled rejection; after the fix each rejects promptly with the underlying error. Also verified the happy path still resolves and that notifications (requests without an `id`) still ignore non-200 responses, per the library's semantics. Biome lint and the `@cartesi/viem` test suite pass.

Includes a patch changeset for `@cartesi/rpc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwVtPsKKS8NBse1uNbcCMC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwVtPsKKS8NBse1uNbcCMC)_