### PR TITLE
Make wagmi-plugin public and add default release configuration

### DIFF
--- a/.changeset/brave-plugins-publish.md
+++ b/.changeset/brave-plugins-publish.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/wagmi-plugin": major
+---
+
+first public release of the wagmi CLI plugin for Cartesi Rollups contracts, with `artifacts` and `deployments` defaulting to the rollups-contracts v3.0.0-alpha.6 GitHub release tarballs (hash-verified)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Formatting/linting is Biome (`biome.json` at root): 4-space indent, double quote
 
 ## Architecture
 
-Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with private `@cartesi/wagmi-plugin` supporting codegen.
+Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with `@cartesi/wagmi-plugin` supporting codegen.
 
 - **packages/rpc (`@cartesi/rpc`)** — Typed JSON-RPC client for the Cartesi node API. `types.ts` and `methods.ts` are hand-written mirrors of the node's `cartesi_*` JSON-RPC methods. Wire types are raw: hex-string quantities and snake_case field names.
 
@@ -34,7 +34,7 @@ Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with 
 
 - **packages/wagmi (`@cartesi/wagmi`)** — React hooks. `src/publicL2/` wraps each viem L2 action in a TanStack Query hook (`useInput`, `useOutputs`, …), using the `CartesiPublicClient` from `provider.tsx` (`CartesiProvider` / `useCartesiClient`). `src/generated.ts` is **generated** contract hooks.
 
-- **packages/wagmi-plugin (`@cartesi/wagmi-plugin`)** — private build tooling: the `rollupsContracts` `@wagmi/cli` plugin, which downloads a rollups-contracts release (build artifacts + deployment addresses tarballs, hash-verified) into the OS temp dir and emits contracts with ABIs and addresses (single address when identical across chains, per-chain otherwise). Supports `include`/`exclude` by contract name; deployed contracts are always included unless excluded.
+- **packages/wagmi-plugin (`@cartesi/wagmi-plugin`)** — the `rollupsContracts` `@wagmi/cli` plugin, which downloads a rollups-contracts release (build artifacts + deployment addresses tarballs, hash-verified) into the OS temp dir and emits contracts with ABIs and addresses (single address when identical across chains, per-chain otherwise). `artifacts`/`deployments` default to the release pinned by `DEFAULT_VERSION` in `src/plugin.ts`. Supports `include`/`exclude` by contract name; deployed contracts are always included unless excluded.
 
 - **apps/docs** — vocs documentation site (`pnpm --filter @cartesi/docs dev`).
 
@@ -42,4 +42,4 @@ Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with 
 
 `pnpm build` in these packages runs `codegen` (= `wagmi generate`) before compiling. Each package's `wagmi.config.ts` uses the `rollupsContracts` plugin from `@cartesi/wagmi-plugin` to produce `src/rollups.ts` (viem) / `src/generated.ts` (wagmi) straight from the pinned rollups-contracts release tarballs; downloads are cached in the OS temp dir.
 
-To bump the rollups-contracts version, update the version and SHA-256 hashes in both packages' `wagmi.config.ts`.
+Both packages use the plugin's default `artifacts`/`deployments`. To bump the rollups-contracts version, update `DEFAULT_VERSION` and the SHA-256 hashes in `packages/wagmi-plugin/src/plugin.ts`.

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -6,6 +6,10 @@ Cartesi provides some TypeScript libraries that helps users to develop Cartesi a
 
 Viem extension library that provides L1 public actions and L1 wallet actions related to Cartesi smart contracts infrastructure, and L2 public actions related to the Cartesi Rollups v2 [JSON-RPC API](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/cartesi/rollups-node/refs/tags/v2.0.0-alpha.10/internal/jsonrpc/jsonrpc-discover.json&uiSchema[appBar][ui:title]=Cartesi&uiSchema[appBar][ui:logoUrl]=https://cartesi.io/favicon.svg&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:edit]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:splitView]=false).
 
+## @cartesi/wagmi-plugin
+
+[Wagmi CLI](https://wagmi.sh/cli/getting-started) plugin that generates code (ABIs and deployment addresses) for the [Cartesi Rollups smart contracts](https://github.com/cartesi/rollups-contracts) directly from an official release.
+
 ## @cartesi/rpc
 
 This library provides a typed JSON-RPC client for the Cartesi Rollups v2 [JSON-RPC API](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/cartesi/rollups-node/refs/tags/v2.0.0-alpha.10/internal/jsonrpc/jsonrpc-discover.json&uiSchema[appBar][ui:title]=Cartesi&uiSchema[appBar][ui:logoUrl]=https://cartesi.io/favicon.svg&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:edit]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:splitView]=false).

--- a/apps/docs/pages/wagmi-plugin/index.mdx
+++ b/apps/docs/pages/wagmi-plugin/index.mdx
@@ -1,0 +1,120 @@
+# Introduction
+
+`@cartesi/wagmi-plugin` is a [Wagmi CLI](https://wagmi.sh/cli/getting-started) plugin that generates code for the [Cartesi Rollups smart contracts](https://github.com/cartesi/rollups-contracts) directly from an official release: ABIs come from the foundry build artifacts tarball, and deployment addresses from the deployment addresses tarball.
+
+Combined with other Wagmi CLI plugins, it can generate fully typed [viem contract actions](https://wagmi.sh/cli/api/plugins/actions) or [React hooks](https://wagmi.sh/cli/api/plugins/react) for the Cartesi contracts. It is the tool used by `@cartesi/viem` and `@cartesi/wagmi` themselves for their code generation.
+
+## Installation
+
+Add the plugin and the Wagmi CLI as development dependencies of your project.
+
+:::code-group
+
+```bash [pnpm]
+pnpm add -D @cartesi/wagmi-plugin @wagmi/cli
+```
+
+```bash [npm]
+npm install --save-dev @cartesi/wagmi-plugin @wagmi/cli
+```
+
+```bash [yarn]
+yarn add -D @cartesi/wagmi-plugin @wagmi/cli
+```
+
+:::
+
+## Usage
+
+Add the plugin to your [wagmi.config.ts](https://wagmi.sh/cli/configuration). With no options, it uses the tarballs of the rollups-contracts `v3.0.0-alpha.6` GitHub release, verified against known SHA-256 hashes.
+
+```ts [wagmi.config.ts]
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [rollupsContracts()],
+});
+```
+
+Then run code generation:
+
+```bash
+pnpm wagmi generate
+```
+
+The generated file exports one ABI per contract, plus its deployment address on every supported chain: a single address when it is identical across chains, or a per-chain record otherwise.
+
+## Using a different release
+
+To generate code from another rollups-contracts release, point `artifacts` and `deployments` at that release's tarballs. Each accepts a plain URL string, or an object with an expected SHA-256 hash of the tarball for integrity verification (recommended).
+
+```ts [wagmi.config.ts]
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+
+const version = "3.0.0-alpha.6";
+const releaseUrl = `https://github.com/cartesi/rollups-contracts/releases/download/v${version}`;
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [
+        rollupsContracts({
+            artifacts: {
+                url: `${releaseUrl}/rollups-contracts-${version}-artifacts.tar.gz`,
+                sha256: "ad1e0880766d25419fc6da1858ea4e7b9074b400e9d9ef68da88b12f4a8bba45",
+            },
+            deployments: {
+                url: `${releaseUrl}/rollups-contracts-${version}-deployment-addresses.tar.gz`,
+                sha256: "bd6ee9b339e0541ce464ea3368e5e70595627b35fe0a68c6f5e044ef433ab895",
+            },
+        }),
+    ],
+});
+```
+
+Tarballs are downloaded and extracted to the operating system temporary directory and cached across runs, so repeated code generation does not download them again.
+
+## Selecting contracts
+
+Deployed contracts are always included. Use `include` to select which contracts *without* a deployment should also be generated (all of them, when omitted), and `exclude` to drop contracts entirely. Both accept contract names or regular expressions.
+
+```ts [wagmi.config.ts]
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [
+        rollupsContracts({
+            include: ["IApplication", "IInputBox", /^IERC\d+Portal$/],
+            exclude: ["SafeERC20Transfer"],
+        }),
+    ],
+});
+```
+
+## Generating React hooks
+
+Compose the plugin with the Wagmi CLI [react plugin](https://wagmi.sh/cli/api/plugins/react) to generate React hooks for the Cartesi contracts.
+
+```ts [wagmi.config.ts]
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+import { react } from "@wagmi/cli/plugins";
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [rollupsContracts(), react()],
+});
+```
+
+## Options
+
+| Option        | Type                                                | Description                                                                                                                                    |
+| ------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `artifacts`   | `string \| { url: string; sha256?: string }`        | Source of the foundry build artifacts tarball. Defaults to the rollups-contracts `v3.0.0-alpha.6` release tarball, hash-verified.               |
+| `deployments` | `string \| { url: string; sha256?: string }`        | Source of the deployment addresses tarball. Defaults to the rollups-contracts `v3.0.0-alpha.6` release tarball, hash-verified.                  |
+| `include`     | `(string \| RegExp)[]`                              | Contracts (by name) to include among those that have no deployment. Deployed contracts are always included. When omitted, all are included.     |
+| `exclude`     | `(string \| RegExp)[]`                              | Contracts (by name) to exclude, deployed or not. Applied after `include`.                                                                       |

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -227,6 +227,15 @@ const config: Config = defineConfig({
             ],
         },
         {
+            text: "Wagmi CLI Plugin",
+            items: [
+                {
+                    text: "Introduction",
+                    link: "/wagmi-plugin",
+                },
+            ],
+        },
+        {
             text: "RPC Client",
             items: [
                 {

--- a/packages/viem/wagmi.config.ts
+++ b/packages/viem/wagmi.config.ts
@@ -1,21 +1,10 @@
 import { rollupsContracts } from "@cartesi/wagmi-plugin";
 import { defineConfig } from "@wagmi/cli";
 
-const version = "3.0.0-alpha.6";
-const releaseUrl = `https://github.com/cartesi/rollups-contracts/releases/download/v${version}`;
-
 const config: ReturnType<typeof defineConfig> = defineConfig({
     out: "src/rollups.ts",
     plugins: [
         rollupsContracts({
-            artifacts: {
-                url: `${releaseUrl}/rollups-contracts-${version}-artifacts.tar.gz`,
-                sha256: "ad1e0880766d25419fc6da1858ea4e7b9074b400e9d9ef68da88b12f4a8bba45",
-            },
-            deployments: {
-                url: `${releaseUrl}/rollups-contracts-${version}-deployment-addresses.tar.gz`,
-                sha256: "bd6ee9b339e0541ce464ea3368e5e70595627b35fe0a68c6f5e044ef433ab895",
-            },
             include: [
                 "DataAvailability",
                 "IApplicationFactory",

--- a/packages/wagmi-plugin/README.md
+++ b/packages/wagmi-plugin/README.md
@@ -1,0 +1,67 @@
+# Cartesi wagmi CLI plugin
+
+A [wagmi CLI](https://wagmi.sh/cli/getting-started) plugin that generates code for the [Cartesi Rollups smart contracts](https://github.com/cartesi/rollups-contracts) straight from an official release: ABIs come from the foundry build artifacts tarball, and deployment addresses from the deployment addresses tarball.
+
+## Installation
+
+```bash
+pnpm add -D @cartesi/wagmi-plugin @wagmi/cli
+```
+
+## Usage
+
+Add the plugin to your `wagmi.config.ts`. By default it uses the tarballs of the rollups-contracts `v3.0.0-alpha.6` GitHub release, verified against known SHA-256 hashes.
+
+```ts
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [rollupsContracts()],
+});
+```
+
+Then run codegen:
+
+```bash
+pnpm wagmi generate
+```
+
+### Using a different release
+
+Point `artifacts` and `deployments` at the tarballs of another rollups-contracts release, optionally with an expected SHA-256 hash for integrity verification:
+
+```ts
+const version = "3.0.0-alpha.6";
+const releaseUrl = `https://github.com/cartesi/rollups-contracts/releases/download/v${version}`;
+
+rollupsContracts({
+    artifacts: {
+        url: `${releaseUrl}/rollups-contracts-${version}-artifacts.tar.gz`,
+        sha256: "ad1e0880766d25419fc6da1858ea4e7b9074b400e9d9ef68da88b12f4a8bba45",
+    },
+    deployments: {
+        url: `${releaseUrl}/rollups-contracts-${version}-deployment-addresses.tar.gz`,
+        sha256: "bd6ee9b339e0541ce464ea3368e5e70595627b35fe0a68c6f5e044ef433ab895",
+    },
+});
+```
+
+### Selecting contracts
+
+Deployed contracts are always included. Use `include` to pick additional contracts that have no deployment (all are included when omitted), and `exclude` to drop contracts entirely. Both accept contract names or regular expressions:
+
+```ts
+rollupsContracts({
+    include: ["IApplication", "IInputBox", /^IERC\d+Portal$/],
+    exclude: ["SafeERC20Transfer"],
+});
+```
+
+## Behavior
+
+- Tarballs are downloaded and extracted to the OS temporary directory and cached across runs.
+- Deployed contracts get their address on every chain: a single address when it is identical across chains, or a per-chain record otherwise.
+
+See the [documentation](https://cartesi.github.io/rollups-ts/) for more details.

--- a/packages/wagmi-plugin/package.json
+++ b/packages/wagmi-plugin/package.json
@@ -2,7 +2,6 @@
     "name": "@cartesi/wagmi-plugin",
     "description": "wagmi CLI plugin for Cartesi Rollups contracts",
     "version": "0.0.0",
-    "private": true,
     "repository": {
         "type": "git",
         "url": "https://github.com/cartesi/rollups-ts"
@@ -48,6 +47,10 @@
         "compile": "tsdown",
         "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
         "dev": "tsdown --watch",
-        "lint": "biome check"
+        "lint": "biome check",
+        "prepack": "run-s build"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/wagmi-plugin/src/plugin.ts
+++ b/packages/wagmi-plugin/src/plugin.ts
@@ -7,19 +7,49 @@ import { downloadAndExtract, type TarballSource } from "./download.js";
 
 export type ContractFilter = string | RegExp;
 
+/**
+ * rollups-contracts version used by default when `artifacts` and
+ * `deployments` are omitted.
+ */
+export const DEFAULT_VERSION = "3.0.0-alpha.6";
+
+const defaultReleaseUrl = `https://github.com/cartesi/rollups-contracts/releases/download/v${DEFAULT_VERSION}`;
+
+/**
+ * Default source of the foundry build artifacts tarball: the
+ * rollups-contracts `DEFAULT_VERSION` GitHub release, hash-verified.
+ */
+export const DEFAULT_ARTIFACTS: TarballSource = {
+    url: `${defaultReleaseUrl}/rollups-contracts-${DEFAULT_VERSION}-artifacts.tar.gz`,
+    sha256: "ad1e0880766d25419fc6da1858ea4e7b9074b400e9d9ef68da88b12f4a8bba45",
+};
+
+/**
+ * Default source of the deployment addresses tarball: the rollups-contracts
+ * `DEFAULT_VERSION` GitHub release, hash-verified.
+ */
+export const DEFAULT_DEPLOYMENTS: TarballSource = {
+    url: `${defaultReleaseUrl}/rollups-contracts-${DEFAULT_VERSION}-deployment-addresses.tar.gz`,
+    sha256: "bd6ee9b339e0541ce464ea3368e5e70595627b35fe0a68c6f5e044ef433ab895",
+};
+
 export interface RollupsContractsOptions {
     /**
      * URL of the rollups-contracts foundry build artifacts tarball, i.e.
      * `rollups-contracts-<version>-artifacts.tar.gz`. Optionally with an
      * expected SHA-256 hash for integrity verification.
+     * Defaults to `DEFAULT_ARTIFACTS`, the tarball of the rollups-contracts
+     * `DEFAULT_VERSION` GitHub release.
      */
-    artifacts: TarballSource;
+    artifacts?: TarballSource;
     /**
      * URL of the rollups-contracts deployment addresses tarball, i.e.
      * `rollups-contracts-<version>-deployment-addresses.tar.gz`. Optionally
      * with an expected SHA-256 hash for integrity verification.
+     * Defaults to `DEFAULT_DEPLOYMENTS`, the tarball of the rollups-contracts
+     * `DEFAULT_VERSION` GitHub release.
      */
-    deployments: TarballSource;
+    deployments?: TarballSource;
     /**
      * Contracts (by name) to include among those that have no deployment.
      * Deployed contracts are always included, regardless of this list.
@@ -148,19 +178,28 @@ const collapseAddress = (
  * Wagmi plugin that generates contracts from a rollups-contracts release:
  * ABIs from the foundry build artifacts tarball, addresses from the
  * deployment addresses tarball. Both tarballs are downloaded and extracted
- * to the OS temporary directory (cached across runs).
+ * to the OS temporary directory (cached across runs). When `artifacts` and
+ * `deployments` are omitted, the tarballs of the rollups-contracts
+ * `DEFAULT_VERSION` GitHub release are used.
  *
  * Deployed contracts get their address across all chains: a single address
  * if it is the same on every chain, or a per-chain record otherwise.
  */
-export const rollupsContracts = (options: RollupsContractsOptions): Plugin => {
-    const { include, exclude } = options;
+export const rollupsContracts = (
+    options: RollupsContractsOptions = {},
+): Plugin => {
+    const {
+        artifacts: artifactsSource = DEFAULT_ARTIFACTS,
+        deployments: deploymentsSource = DEFAULT_DEPLOYMENTS,
+        include,
+        exclude,
+    } = options;
     return {
         name: "rollupsContracts",
         contracts: async () => {
             const [artifactsDir, deploymentsDir] = await Promise.all([
-                downloadAndExtract(options.artifacts),
-                downloadAndExtract(options.deployments),
+                downloadAndExtract(artifactsSource),
+                downloadAndExtract(deploymentsSource),
             ]);
 
             // tarballs contain the `out` (resp. `deployments`) directory

--- a/packages/wagmi/wagmi.config.ts
+++ b/packages/wagmi/wagmi.config.ts
@@ -2,21 +2,10 @@ import { rollupsContracts } from "@cartesi/wagmi-plugin";
 import { defineConfig } from "@wagmi/cli";
 import { actions, react } from "@wagmi/cli/plugins";
 
-const version = "3.0.0-alpha.6";
-const releaseUrl = `https://github.com/cartesi/rollups-contracts/releases/download/v${version}`;
-
 const config: ReturnType<typeof defineConfig> = defineConfig({
     out: "src/generated.ts",
     plugins: [
         rollupsContracts({
-            artifacts: {
-                url: `${releaseUrl}/rollups-contracts-${version}-artifacts.tar.gz`,
-                sha256: "ad1e0880766d25419fc6da1858ea4e7b9074b400e9d9ef68da88b12f4a8bba45",
-            },
-            deployments: {
-                url: `${releaseUrl}/rollups-contracts-${version}-deployment-addresses.tar.gz`,
-                sha256: "bd6ee9b339e0541ce464ea3368e5e70595627b35fe0a68c6f5e044ef433ab895",
-            },
             include: [
                 "DataAvailability",
                 "IApplicationFactory",


### PR DESCRIPTION
## Summary

This PR makes the `@cartesi/wagmi-plugin` package public and improves its usability by providing sensible defaults for the rollups-contracts release configuration.

## Key Changes

- **Made `@cartesi/wagmi-plugin` public**: Removed the `"private": true` flag from `package.json` and added `publishConfig` with public access, enabling the package to be published to npm
- **Added default release configuration**: Introduced `DEFAULT_VERSION`, `DEFAULT_ARTIFACTS`, and `DEFAULT_DEPLOYMENTS` constants that point to the rollups-contracts `v3.0.0-alpha.6` GitHub release with hash verification
- **Made plugin options optional**: Changed `artifacts` and `deployments` from required to optional parameters in `RollupsContractsOptions`, allowing users to call `rollupsContracts()` with no arguments
- **Simplified consumer configurations**: Updated `@cartesi/viem` and `@cartesi/wagmi` wagmi configs to remove explicit artifact/deployment URLs and hashes, now relying on the plugin defaults
- **Added comprehensive documentation**: Created documentation page at `apps/docs/pages/wagmi-plugin/index.mdx` with installation, usage, and configuration examples, plus updated the main docs index to include the new section
- **Updated package README**: Added `packages/wagmi-plugin/README.md` with quick-start guide and usage examples
- **Enhanced code documentation**: Added JSDoc comments explaining the default version and tarball sources
- **Updated architecture documentation**: Modified `CLAUDE.md` to reflect that `@cartesi/wagmi-plugin` is no longer private

## Implementation Details

- Default artifacts and deployments use hash-verified URLs from the official GitHub release, ensuring integrity
- Tarballs are cached in the OS temporary directory across runs to avoid repeated downloads
- The plugin maintains backward compatibility—users can still provide custom artifact/deployment sources
- All existing functionality (contract filtering, React hook generation) remains unchanged

https://claude.ai/code/session_01PsQGEZEW8dcsNqgS3juAJx