### PR TITLE
feat(wagmi-plugin): apply include/exclude to all contracts uniformly

### DIFF
--- a/.changeset/witty-donkeys-filter.md
+++ b/.changeset/witty-donkeys-filter.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/wagmi-plugin": patch
+---
+
+apply `include`/`exclude` to all contracts, deployed or not: when neither is given all contracts in the artifacts are included, `include` narrows generation to the matching contracts, and `exclude` is applied after `include`. Deployed contracts are no longer implicitly included, so configs relying on that must list them in `include`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with 
 
 - **packages/wagmi (`@cartesi/wagmi`)** — React hooks. `src/publicL2/` wraps each viem L2 action in a TanStack Query hook (`useInput`, `useOutputs`, …), using the `CartesiPublicClient` from `provider.tsx` (`CartesiProvider` / `useCartesiClient`). `src/generated.ts` is **generated** contract hooks.
 
-- **packages/wagmi-plugin (`@cartesi/wagmi-plugin`)** — the `rollupsContracts` `@wagmi/cli` plugin, which downloads a rollups-contracts release (build artifacts + deployment addresses tarballs, hash-verified) into the OS temp dir and emits contracts with ABIs and addresses (single address when identical across chains, per-chain otherwise). `artifacts`/`deployments` default to the release pinned by `DEFAULT_VERSION` in `src/plugin.ts`. Supports `include`/`exclude` by contract name; deployed contracts are always included unless excluded.
+- **packages/wagmi-plugin (`@cartesi/wagmi-plugin`)** — the `rollupsContracts` `@wagmi/cli` plugin, which downloads a rollups-contracts release (build artifacts + deployment addresses tarballs, hash-verified) into the OS temp dir and emits contracts with ABIs and addresses (single address when identical across chains, per-chain otherwise). `artifacts`/`deployments` default to the release pinned by `DEFAULT_VERSION` in `src/plugin.ts`. Supports `include`/`exclude` by contract name (or regex), applied to all contracts alike: when neither is given all contracts in the artifacts are included, `include` narrows the set, and `exclude` is applied after `include`.
 
 - **apps/docs** — vocs documentation site (`pnpm --filter @cartesi/docs dev`).
 

--- a/apps/docs/pages/wagmi-plugin/index.mdx
+++ b/apps/docs/pages/wagmi-plugin/index.mdx
@@ -78,7 +78,14 @@ Tarballs are downloaded and extracted to the operating system temporary director
 
 ## Selecting contracts
 
-Deployed contracts are always included. Use `include` to select which contracts *without* a deployment should also be generated (all of them, when omitted), and `exclude` to drop contracts entirely. Both accept contract names or regular expressions.
+Use `include` and `exclude` to select which contracts are generated. Both accept contract names or regular expressions, and apply to every contract in the artifacts, whether it has a deployment or not:
+
+- Neither defined: all contracts are included.
+- Only `include`: only the matching contracts are included.
+- Only `exclude`: all contracts are included except the matching ones.
+- Both: `include` is applied first, then `exclude`.
+
+For example, to generate only the `Inputs` and `Outputs` contracts:
 
 ```ts [wagmi.config.ts]
 import { rollupsContracts } from "@cartesi/wagmi-plugin";
@@ -88,8 +95,24 @@ export default defineConfig({
     out: "src/generated.ts",
     plugins: [
         rollupsContracts({
-            include: ["IApplication", "IInputBox", /^IERC\d+Portal$/],
-            exclude: ["SafeERC20Transfer"],
+            include: ["Inputs", "Outputs"],
+        }),
+    ],
+});
+```
+
+Or to generate all portal contracts except the interfaces:
+
+```ts [wagmi.config.ts]
+import { rollupsContracts } from "@cartesi/wagmi-plugin";
+import { defineConfig } from "@wagmi/cli";
+
+export default defineConfig({
+    out: "src/generated.ts",
+    plugins: [
+        rollupsContracts({
+            include: [/Portal$/],
+            exclude: [/^I[A-Z]/],
         }),
     ],
 });
@@ -116,5 +139,5 @@ export default defineConfig({
 | ------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `artifacts`   | `string \| { url: string; sha256?: string }`        | Source of the foundry build artifacts tarball. Defaults to the rollups-contracts `v3.0.0-alpha.6` release tarball, hash-verified.               |
 | `deployments` | `string \| { url: string; sha256?: string }`        | Source of the deployment addresses tarball. Defaults to the rollups-contracts `v3.0.0-alpha.6` release tarball, hash-verified.                  |
-| `include`     | `(string \| RegExp)[]`                              | Contracts (by name) to include among those that have no deployment. Deployed contracts are always included. When omitted, all are included.     |
-| `exclude`     | `(string \| RegExp)[]`                              | Contracts (by name) to exclude, deployed or not. Applied after `include`.                                                                       |
+| `include`     | `(string \| RegExp)[]`                              | Contracts (by name or regular expression) to include, deployed or not. When omitted, all contracts in the artifacts are included.               |
+| `exclude`     | `(string \| RegExp)[]`                              | Contracts (by name or regular expression) to exclude, deployed or not. Applied after `include`.                                                 |

--- a/packages/viem/wagmi.config.ts
+++ b/packages/viem/wagmi.config.ts
@@ -6,7 +6,14 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     plugins: [
         rollupsContracts({
             include: [
+                "ApplicationFactory",
+                "AuthorityFactory",
                 "DataAvailability",
+                "ERC1155BatchPortal",
+                "ERC1155SinglePortal",
+                "ERC20Portal",
+                "ERC721Portal",
+                "EtherPortal",
                 "IApplicationFactory",
                 "IApplication",
                 "IAuthorityFactory",
@@ -18,6 +25,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
                 "IERC721Portal",
                 "IEtherPortal",
                 "IInputBox",
+                "InputBox",
                 "Inputs",
                 "IOutputsMerkleRootValidator",
                 "IQuorumFactory",
@@ -29,6 +37,10 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
                 "IUsdWithdrawalOutputBuilder",
                 "IWithdrawalOutputBuilder",
                 "Outputs",
+                "QuorumFactory",
+                "SafeERC20Transfer",
+                "SelfHostedApplicationFactory",
+                "UsdWithdrawalOutputBuilderFactory",
             ],
         }),
     ],

--- a/packages/wagmi-plugin/README.md
+++ b/packages/wagmi-plugin/README.md
@@ -50,12 +50,27 @@ rollupsContracts({
 
 ### Selecting contracts
 
-Deployed contracts are always included. Use `include` to pick additional contracts that have no deployment (all are included when omitted), and `exclude` to drop contracts entirely. Both accept contract names or regular expressions:
+Use `include` and `exclude` to select which contracts are generated. Both accept contract names or regular expressions, and apply to every contract in the artifacts, whether it has a deployment or not:
+
+- Neither defined: all contracts are included.
+- Only `include`: only the matching contracts are included.
+- Only `exclude`: all contracts are included except the matching ones.
+- Both: `include` is applied first, then `exclude`.
+
+For example, to generate only the `Inputs` and `Outputs` contracts:
 
 ```ts
 rollupsContracts({
-    include: ["IApplication", "IInputBox", /^IERC\d+Portal$/],
-    exclude: ["SafeERC20Transfer"],
+    include: ["Inputs", "Outputs"],
+});
+```
+
+Or to generate all portal contracts except the interfaces:
+
+```ts
+rollupsContracts({
+    include: [/Portal$/],
+    exclude: [/^I[A-Z]/],
 });
 ```
 

--- a/packages/wagmi-plugin/src/plugin.ts
+++ b/packages/wagmi-plugin/src/plugin.ts
@@ -51,14 +51,13 @@ export interface RollupsContractsOptions {
      */
     deployments?: TarballSource;
     /**
-     * Contracts (by name) to include among those that have no deployment.
-     * Deployed contracts are always included, regardless of this list.
+     * Contracts (by name or regular expression) to include, deployed or not.
      * When omitted, all contracts in the artifacts are included.
      */
     include?: ContractFilter[];
     /**
-     * Contracts (by name) to exclude, deployed or not. Applied after
-     * `include`.
+     * Contracts (by name or regular expression) to exclude, deployed or not.
+     * Applied after `include`.
      */
     exclude?: ContractFilter[];
 }
@@ -184,6 +183,11 @@ const collapseAddress = (
  *
  * Deployed contracts get their address across all chains: a single address
  * if it is the same on every chain, or a per-chain record otherwise.
+ *
+ * `include` and `exclude` filter all contracts alike, deployed or not: when
+ * neither is given every contract in the artifacts is generated, `include`
+ * narrows generation to the matching contracts, and `exclude` then drops
+ * matching contracts.
  */
 export const rollupsContracts = (
     options: RollupsContractsOptions = {},
@@ -194,6 +198,8 @@ export const rollupsContracts = (
         include,
         exclude,
     } = options;
+    const included = (name: string): boolean =>
+        (include ? matches(name, include) : true) && !matches(name, exclude);
     return {
         name: "rollupsContracts",
         contracts: async () => {
@@ -215,7 +221,7 @@ export const rollupsContracts = (
             );
 
             for (const name of deployments.keys()) {
-                if (!artifacts.has(name) && !matches(name, exclude)) {
+                if (included(name) && !artifacts.has(name)) {
                     throw new Error(
                         `Deployed contract ${name} has no build artifact`,
                     );
@@ -223,15 +229,7 @@ export const rollupsContracts = (
             }
 
             return [...artifacts.entries()]
-                .filter(([name]) => {
-                    if (matches(name, exclude)) {
-                        return false;
-                    }
-                    if (deployments.has(name)) {
-                        return true;
-                    }
-                    return include ? matches(name, include) : true;
-                })
+                .filter(([name]) => included(name))
                 .sort(([a], [b]) => a.localeCompare(b))
                 .flatMap(([name, artifactPath]) => {
                     const abi = readAbi(artifactPath, name);

--- a/packages/wagmi/wagmi.config.ts
+++ b/packages/wagmi/wagmi.config.ts
@@ -7,7 +7,14 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     plugins: [
         rollupsContracts({
             include: [
+                "ApplicationFactory",
+                "AuthorityFactory",
                 "DataAvailability",
+                "ERC1155BatchPortal",
+                "ERC1155SinglePortal",
+                "ERC20Portal",
+                "ERC721Portal",
+                "EtherPortal",
                 "IApplicationFactory",
                 "IApplication",
                 "IAuthorityFactory",
@@ -19,6 +26,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
                 "IERC721Portal",
                 "IEtherPortal",
                 "IInputBox",
+                "InputBox",
                 "Inputs",
                 "IOutputsMerkleRootValidator",
                 "IQuorumFactory",
@@ -30,6 +38,10 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
                 "IUsdWithdrawalOutputBuilder",
                 "IWithdrawalOutputBuilder",
                 "Outputs",
+                "QuorumFactory",
+                "SafeERC20Transfer",
+                "SelfHostedApplicationFactory",
+                "UsdWithdrawalOutputBuilderFactory",
             ],
         }),
         actions(),


### PR DESCRIPTION
## Why

The `include` option of the `rollupsContracts` plugin previously only applied to contracts *without* a deployment — deployed contracts were always included, regardless of the list. This made it hard (effectively impossible) to generate only a small set of contracts, like just `Inputs` and `Outputs`: every deployed contract would ride along unless each one was individually excluded.

## What

`include` and `exclude` now filter all contracts alike, deployed or not:

- **Neither defined**: all contracts in the artifacts are included.
- **Only `include`**: only the matching contracts are included.
- **Only `exclude`**: all contracts are included except the matching ones.
- **Both**: `include` is applied first, then `exclude`.

So `rollupsContracts({ include: ["Inputs", "Outputs"] })` now generates exactly those two contracts. A deployment without a build artifact is also only an error when the contract passes the filters, so a filtered-out deployment no longer aborts codegen.

Since deployed contracts are no longer implicitly included, the `include` lists of `@cartesi/viem` and `@cartesi/wagmi` gain the deployed contract names they previously got for free. Their generated output is unchanged — verified byte-identical before and after the change.

Documentation is updated accordingly: the plugin README, the docs site page (including the options table), and CLAUDE.md, plus a changeset marking the behavior change.

## Note on future artifacts

The next rollups-contracts release will pre-filter the contracts in its artifacts tarball, so for the standard use case an inclusion list will likely no longer be necessary — the default (no `include`/`exclude` → everything in the artifacts) will just do the right thing. The uniform filtering semantics introduced here are what make that default sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RjR1NPDrLWPBKhjsgoFQN

---
_Generated by [Claude Code](https://claude.ai/code/session_016RjR1NPDrLWPBKhjsgoFQN)_