### PR TITLE
Add sequencer wallet extension

### DIFF
--- a/.changeset/fuzzy-sequencers-sign.md
+++ b/.changeset/fuzzy-sequencers-sign.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/viem": minor
+---
+
+Add a Cartesi sequencer client that signs canonical EIP-712 user operations with local accounts or Wallet Clients and submits them to the sequencer HTTP API.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Repository overview
+
+pnpm + Turborepo monorepo of Cartesi Rollups TypeScript libraries. Requires Node >= 22 and pnpm (see `packageManager` in package.json). Shared dependency versions are pinned in the `catalog:` section of `pnpm-workspace.yaml`.
+
+## Commands
+
+- `pnpm build` — build all packages (turbo; for viem/wagmi this runs codegen first, see below)
+- `pnpm dev` — watch mode (tsdown --watch) across packages
+- `pnpm lint` — `biome check` in each package
+- `pnpm check-types` — TypeScript type checking
+- Tests (`@cartesi/viem` and `@cartesi/codec` have tests, via vitest):
+  - `pnpm --filter @cartesi/viem test` — watch mode
+  - `pnpm --filter @cartesi/viem test:coverage` — single run with coverage
+  - Single test: `pnpm --filter @cartesi/viem exec vitest run __tests__/converter.test.ts`
+- Releases use changesets: `pnpm changeset` to add one; versioning/publishing is `pnpm version-packages` / `pnpm release`. Packages are currently on 2.0.0-alpha prereleases.
+
+Formatting/linting is Biome (`biome.json` at root): 4-space indent, double quotes. All packages are ESM (`"type": "module"`) and use `.js` extensions on relative imports (NodeNext resolution). Builds are done with tsdown, emitting dual ESM/CJS to `dist/`.
+
+## Architecture
+
+Dependency chain: `@cartesi/rpc` → `@cartesi/viem` → `@cartesi/wagmi`, with `@cartesi/wagmi-plugin` supporting codegen.
+
+- **packages/rpc (`@cartesi/rpc`)** — Typed JSON-RPC client for the Cartesi node API. `types.ts` and `methods.ts` are hand-written mirrors of the node's `cartesi_*` JSON-RPC methods. Wire types are raw: hex-string quantities and snake_case field names.
+
+- **packages/viem (`@cartesi/viem`)** — viem extension, structured like viem itself:
+  - `src/actions/` — one file per action. **L2 actions** (getInput, listOutputs, waitForInput, …) call `cartesi_*` RPC methods on a Cartesi node through a viem transport. L1 contract interactions are done with plain viem contract actions using the generated ABIs/addresses exported via the `@cartesi/viem/abi` entrypoint (plus the `toOutputArgs` output-conversion helper).
+  - `src/types/converter.ts` — converts raw RPC wire types (hex/snake_case, from `@cartesi/rpc`) into friendly types (bigint/camelCase, defined in `src/types/actions.ts` and `src/types/output.ts`). New RPC-backed actions follow this pattern: request with raw params, convert the response.
+  - `src/decorators/` — `publicActionsL2` (Cartesi node RPC schema + actions); `src/clients/createCartesiPublicClient.ts` creates a viem client bound to the Cartesi RPC schema.
+  - `src/rollups.ts` is **generated** — do not edit by hand (see Codegen).
+
+- **packages/wagmi (`@cartesi/wagmi`)** — React hooks. `src/publicL2/` wraps each viem L2 action in a TanStack Query hook (`useInput`, `useOutputs`, …), using the `CartesiPublicClient` from `provider.tsx` (`CartesiProvider` / `useCartesiClient`). `src/generated.ts` is **generated** contract hooks.
+
+- **packages/codec (`@cartesi/codec`)** — isomorphic encode/decode of input and output blobs, which are ABI-encoded calls to the rollups contracts `Inputs` (`EvmAdvance`) and `Outputs` (`Notice`, `Voucher`, `DelegateCallVoucher`) interfaces, and of portal deposit payloads (`src/portal.ts`), which are packed-encoded per the rollups contracts `InputEncoding` library. `src/rollups.ts` is **generated** (see Codegen); depends only on viem (peer) and abitype.
+
+- **packages/wagmi-plugin (`@cartesi/wagmi-plugin`)** — the `rollupsContracts` `@wagmi/cli` plugin, which downloads a rollups-contracts release (build artifacts + deployment addresses tarballs, hash-verified) into the OS temp dir and emits contracts with ABIs and addresses (single address when identical across chains, per-chain otherwise). `artifacts`/`deployments` default to the release pinned by `DEFAULT_VERSION` in `src/plugin.ts`. Supports `include`/`exclude` by contract name (or regex), applied to all contracts alike: when neither is given all contracts in the artifacts are included, `include` narrows the set, and `exclude` is applied after `include`.
+
+- **apps/docs** — vocs documentation site (`pnpm --filter @cartesi/docs dev`).
+
+### Codegen (viem, wagmi and codec packages)
+
+`pnpm build` in these packages runs `codegen` (= `wagmi generate`) before compiling. Each package's `wagmi.config.ts` uses the `rollupsContracts` plugin from `@cartesi/wagmi-plugin` to produce `src/rollups.ts` (viem, codec) / `src/generated.ts` (wagmi) straight from the pinned rollups-contracts release tarballs; downloads are cached in the OS temp dir.
+
+Both packages use the plugin's default `artifacts`/`deployments`. To bump the rollups-contracts version, update `DEFAULT_VERSION` and the SHA-256 hashes in `packages/wagmi-plugin/src/plugin.ts`.

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -4,7 +4,7 @@ Cartesi provides some TypeScript libraries that helps users to develop Cartesi a
 
 ## @cartesi/viem
 
-Viem extension library that provides L1 public actions and L1 wallet actions related to Cartesi smart contracts infrastructure, and L2 public actions related to the Cartesi Rollups v2 [JSON-RPC API](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/cartesi/rollups-node/refs/tags/v2.0.0-alpha.10/internal/jsonrpc/jsonrpc-discover.json&uiSchema[appBar][ui:title]=Cartesi&uiSchema[appBar][ui:logoUrl]=https://cartesi.io/favicon.svg&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:edit]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:splitView]=false).
+Viem extension library that provides L1 contract utilities, a dedicated client for sending EIP-712 transactions to a Cartesi sequencer, and L2 public actions related to the Cartesi Rollups v2 [JSON-RPC API](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/cartesi/rollups-node/refs/tags/v2.0.0-alpha.10/internal/jsonrpc/jsonrpc-discover.json&uiSchema[appBar][ui:title]=Cartesi&uiSchema[appBar][ui:logoUrl]=https://cartesi.io/favicon.svg&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:edit]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:splitView]=false).
 
 ## @cartesi/wagmi-plugin
 

--- a/apps/docs/pages/viem/index.mdx
+++ b/apps/docs/pages/viem/index.mdx
@@ -9,6 +9,11 @@ It provides L2 public actions and a new `createCartesiPublicClient` client const
 Interactions with the Cartesi rollups [smart contracts](https://github.com/cartesi/rollups-contracts) infrastructure, like sending inputs, depositing assets and executing outputs, are done with viem's own contract actions, using the properly typed ABIs and deployment addresses exported by the `@cartesi/viem/abi` entrypoint.
 Check the [L1 Contract Interactions](/viem/l1) guide for details.
 
+## Sequencer Transactions
+
+The `@cartesi/viem/sequencer` entrypoint provides a dedicated client for signing and sending application transactions to a Cartesi sequencer. It supports both browser wallets such as MetaMask and local viem accounts.
+Check the [Sequencer Transactions](/viem/sequencer) guide for setup and API details.
+
 ## Public L2 Actions
 
 Provides convenient methods to interact with Cartesi JSON-RPC API, which provides read-only access to the app specific L2.

--- a/apps/docs/pages/viem/l1.mdx
+++ b/apps/docs/pages/viem/l1.mdx
@@ -1,6 +1,6 @@
 # L1 Contract Interactions
 
-Transactions related to Cartesi applications are sent directly to the base layer (L1) as regular contract interactions with the Cartesi Rollups [smart contracts](https://github.com/cartesi/rollups-contracts).
+Base-layer operations related to Cartesi applications, such as depositing assets and executing outputs, are regular contract interactions with the Cartesi Rollups [smart contracts](https://github.com/cartesi/rollups-contracts).
 
 Instead of providing custom actions, this library exports typed ABIs and deployment addresses of all Cartesi Rollups contracts through the `@cartesi/viem/abi` entrypoint, to be used with viem's own contract actions, like [writeContract](https://viem.sh/docs/contract/writeContract), [readContract](https://viem.sh/docs/contract/readContract), [simulateContract](https://viem.sh/docs/contract/simulateContract) and [estimateContractGas](https://viem.sh/docs/contract/estimateContractGas).
 
@@ -11,6 +11,10 @@ Instead of providing custom actions, this library exports typed ABIs and deploym
 ## Sending inputs
 
 Send a generic input to an application through the `InputBox` contract.
+
+:::note
+This is the direct L1 input path. To sign an application transaction with a Wallet Client and submit it through a Cartesi sequencer instead, see [Sequencer Transactions](/viem/sequencer).
+:::
 
 ```ts twoslash
 import { http, stringToHex } from "viem";

--- a/apps/docs/pages/viem/sequencer.mdx
+++ b/apps/docs/pages/viem/sequencer.mdx
@@ -1,0 +1,217 @@
+# Sequencer Transactions
+
+The `@cartesi/viem/sequencer` entrypoint provides a dedicated client for sending transactions to a [Cartesi sequencer](https://github.com/cartesi/sequencer). Transactions are signed as [EIP-712 typed data](https://viem.sh/docs/actions/wallet/signTypedData) and submitted to the sequencer HTTP API.
+
+The sequencer is a separate service, so its client is separate from viem's L1 Wallet Client. A browser wallet can still sign transactions by supplying its Wallet Client as the sequencer client's signer.
+
+## Browser wallets
+
+Create a viem [`WalletClient`](https://viem.sh/docs/clients/wallet) from the wallet's EIP-1193 provider, then pass it to `createSequencerClient`. With MetaMask, signing opens the normal typed-data confirmation prompt.
+
+```ts
+import { createSequencerClient } from "@cartesi/viem/sequencer";
+import {
+  createWalletClient,
+  custom,
+  http,
+  type Address,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+const [account] = (await window.ethereum.request({
+  method: "eth_requestAccounts",
+})) as [Address, ...Address[]];
+
+const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum),
+});
+
+const sequencerClient = createSequencerClient({
+  account,
+  application: "0x...",
+  chain: mainnet,
+  transport: http("https://sequencer.example.com"),
+  walletClient,
+});
+
+const receipt = await sequencerClient.sendTransaction({
+  data: "0x...",
+  maxFee: 1_200,
+  nonce: 0,
+});
+```
+
+The two transports have distinct responsibilities:
+
+- `custom(window.ethereum)` sends signing requests such as `eth_signTypedData_v4` to MetaMask.
+- `http("https://sequencer.example.com")` submits signed transactions to the sequencer's `/tx` endpoint.
+
+The private key is never exposed to either client.
+
+:::note
+The sequencer client's `chain` determines the EIP-712 `chainId`. It must match both the connected wallet network and the chain configured by the sequencer.
+:::
+
+## Local accounts
+
+For a viem local account, pass the account directly and omit `walletClient`. Viem signs locally, so the sequencer transport is never used for wallet RPC.
+
+```ts twoslash
+import { createSequencerClient } from "@cartesi/viem/sequencer";
+import { http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+
+const account = privateKeyToAccount("0x...");
+
+const sequencerClient = createSequencerClient({
+  account,
+  application: "0x...",
+  chain: mainnet,
+  transport: http("https://sequencer.example.com"),
+});
+
+const receipt = await sequencerClient.sendTransaction({
+  data: "0x...",
+  maxFee: 1_200,
+  nonce: 0,
+});
+```
+
+## Actions
+
+### `sendTransaction`
+
+Signs the transaction and immediately submits it to the configured sequencer. This is the usual action for an application frontend.
+
+```ts
+const receipt = await sequencerClient.sendTransaction({
+  data: "0x...",
+  maxFee: 1_200,
+  nonce: 0,
+});
+```
+
+The returned receipt is the sequencer's soft confirmation:
+
+```ts
+type SequencerTransactionReceipt = {
+  ok: true;
+  sender: Address;
+  nonce: number;
+};
+```
+
+A soft confirmation means that the sequencer accepted the transaction. It is not an L1 transaction receipt or a finality guarantee.
+
+### `signTransaction`
+
+Signs without making an HTTP request to the sequencer. Use this when submission happens later or through another process.
+
+```ts
+const transaction = await sequencerClient.signTransaction({
+  data: "0x...",
+  maxFee: 1_200,
+  nonce: 0,
+});
+```
+
+It returns the exact payload accepted by the sequencer:
+
+```ts
+type SignedSequencerTransaction = {
+  message: {
+    data: Hex;
+    max_fee: number;
+    nonce: number;
+  };
+  sender: Address;
+  signature: Hex;
+};
+```
+
+### `submitTransaction`
+
+Submits an already signed transaction without asking the account to sign again. This complements `signTransaction` for deferred submission and relayer-style flows.
+
+```ts
+const receipt = await sequencerClient.submitTransaction({
+  transaction,
+});
+```
+
+In short, `sendTransaction` is the sign-and-submit convenience action, while `submitTransaction` performs only the submission step.
+
+## Client configuration
+
+| Parameter | Description |
+| --- | --- |
+| `account` | Local account or JSON-RPC account address that signs transactions. |
+| `application` | Application address used as the EIP-712 verifying contract. |
+| `chain` | L1 chain whose ID is included in the EIP-712 domain. |
+| `transport` | Viem HTTP transport pointed at the sequencer base URL. |
+| `walletClient` | Required for JSON-RPC accounts such as MetaMask; omitted for local accounts. |
+
+The HTTP transport accepts normal viem configuration such as request headers and a timeout:
+
+```ts
+createSequencerClient({
+  account,
+  application: "0x...",
+  chain: mainnet,
+  transport: http("https://sequencer.example.com", {
+    timeout: 10_000,
+    fetchOptions: {
+      headers: { "x-api-key": "..." },
+    },
+  }),
+  walletClient,
+});
+```
+
+## Transaction parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `data` | `Hex` | Application-defined, SSZ-encoded method payload. |
+| `maxFee` | `number` | Maximum fee as the sequencer protocol's `uint16` exponent. |
+| `nonce` | `number` | Sender nonce as an unsigned `uint32`. |
+| `account` | `Account \| Address` | Optional account override; defaults to the client account. |
+
+The current sequencer API does not discover the next nonce or estimate the fee. Applications must obtain those values from their own state or indexing service.
+
+## EIP-712 message
+
+The client signs a `UserOp` typed-data message with this domain:
+
+| Field | Value |
+| --- | --- |
+| `name` | `CartesiAppSequencer` |
+| `version` | `1` |
+| `chainId` | The sequencer client chain ID |
+| `verifyingContract` | The configured application address |
+
+The `UserOp` fields are `nonce: uint32`, `max_fee: uint16`, and `data: bytes`.
+
+## Errors and retries
+
+Rejected transactions throw `SequencerTransactionRejectedError`, which exposes the HTTP `status`, sequencer `code`, and structured response `body`. Network failures throw `SequencerRequestError`, and malformed HTTP responses throw `SequencerResponseError`.
+
+```ts
+import { SequencerTransactionRejectedError } from "@cartesi/viem/sequencer";
+
+try {
+  await sequencerClient.sendTransaction({
+    data: "0x...",
+    maxFee: 1_200,
+    nonce: 0,
+  });
+} catch (error) {
+  if (error instanceof SequencerTransactionRejectedError) {
+    console.error(error.code, error.body.message);
+  }
+}
+```
+
+The client does not retry submissions automatically. A request that times out may already have been accepted, so retry only after checking transaction state and nonce handling for the application.

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -34,6 +34,10 @@ const config: Config = defineConfig({
                     link: "/viem/l1",
                 },
                 {
+                    text: "Sequencer Transactions",
+                    link: "/viem/sequencer",
+                },
+                {
                     text: "Public L2 Actions",
                     collapsed: true,
                     items: [

--- a/packages/codec/src/rollups.ts
+++ b/packages/codec/src/rollups.ts
@@ -1,0 +1,378 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ERC1155BatchPortal
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const erc1155BatchPortalAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'inputBox',
+                internalType: 'contract IInputBox',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            {
+                name: 'token',
+                internalType: 'contract IERC1155',
+                type: 'address',
+            },
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'tokenIds', internalType: 'uint256[]', type: 'uint256[]' },
+            { name: 'values', internalType: 'uint256[]', type: 'uint256[]' },
+            { name: 'baseLayerData', internalType: 'bytes', type: 'bytes' },
+            { name: 'execLayerData', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'depositBatchERC1155Token',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getInputBox',
+        outputs: [
+            { name: '', internalType: 'contract IInputBox', type: 'address' },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+] as const
+
+export const erc1155BatchPortalAddress =
+    '0x3649c5E2De91C69a7Bb80D864f0039da5E511096' as const
+
+export const erc1155BatchPortalConfig = {
+    address: erc1155BatchPortalAddress,
+    abi: erc1155BatchPortalAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ERC1155SinglePortal
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const erc1155SinglePortalAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'inputBox',
+                internalType: 'contract IInputBox',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            {
+                name: 'token',
+                internalType: 'contract IERC1155',
+                type: 'address',
+            },
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'tokenId', internalType: 'uint256', type: 'uint256' },
+            { name: 'value', internalType: 'uint256', type: 'uint256' },
+            { name: 'baseLayerData', internalType: 'bytes', type: 'bytes' },
+            { name: 'execLayerData', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'depositSingleERC1155Token',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getInputBox',
+        outputs: [
+            { name: '', internalType: 'contract IInputBox', type: 'address' },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+] as const
+
+export const erc1155SinglePortalAddress =
+    '0x13663E193673756a02e84b724B8a3422A9a7aab4' as const
+
+export const erc1155SinglePortalConfig = {
+    address: erc1155SinglePortalAddress,
+    abi: erc1155SinglePortalAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ERC20Portal
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const erc20PortalAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'inputBox',
+                internalType: 'contract IInputBox',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            { name: 'token', internalType: 'contract IERC20', type: 'address' },
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'value', internalType: 'uint256', type: 'uint256' },
+            { name: 'execLayerData', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'depositERC20Tokens',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getInputBox',
+        outputs: [
+            { name: '', internalType: 'contract IInputBox', type: 'address' },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+    { type: 'error', inputs: [], name: 'ERC20TransferFailed' },
+] as const
+
+export const erc20PortalAddress =
+    '0x22E57511C30CcE6CDaa742E13CE3b774fDC663b1' as const
+
+export const erc20PortalConfig = {
+    address: erc20PortalAddress,
+    abi: erc20PortalAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ERC721Portal
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const erc721PortalAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'inputBox',
+                internalType: 'contract IInputBox',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            {
+                name: 'token',
+                internalType: 'contract IERC721',
+                type: 'address',
+            },
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'tokenId', internalType: 'uint256', type: 'uint256' },
+            { name: 'baseLayerData', internalType: 'bytes', type: 'bytes' },
+            { name: 'execLayerData', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'depositERC721Token',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getInputBox',
+        outputs: [
+            { name: '', internalType: 'contract IInputBox', type: 'address' },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+] as const
+
+export const erc721PortalAddress =
+    '0xcA3a0a47915C12F020CF70B938aCC8e744414cb8' as const
+
+export const erc721PortalConfig = {
+    address: erc721PortalAddress,
+    abi: erc721PortalAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// EtherPortal
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const etherPortalAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'inputBox',
+                internalType: 'contract IInputBox',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'execLayerData', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'depositEther',
+        outputs: [],
+        stateMutability: 'payable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getInputBox',
+        outputs: [
+            { name: '', internalType: 'contract IInputBox', type: 'address' },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+    { type: 'error', inputs: [], name: 'EtherTransferFailed' },
+] as const
+
+export const etherPortalAddress =
+    '0x8b53327575ac999bdfa8003f4b5134DFF9027516' as const
+
+export const etherPortalConfig = {
+    address: etherPortalAddress,
+    abi: etherPortalAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Inputs
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const inputsAbi = [
+    {
+        type: 'function',
+        inputs: [
+            { name: 'chainId', internalType: 'uint256', type: 'uint256' },
+            { name: 'appContract', internalType: 'address', type: 'address' },
+            { name: 'msgSender', internalType: 'address', type: 'address' },
+            { name: 'blockNumber', internalType: 'uint256', type: 'uint256' },
+            {
+                name: 'blockTimestamp',
+                internalType: 'uint256',
+                type: 'uint256',
+            },
+            { name: 'prevRandao', internalType: 'uint256', type: 'uint256' },
+            { name: 'index', internalType: 'uint256', type: 'uint256' },
+            { name: 'payload', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'EvmAdvance',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+] as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Outputs
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const outputsAbi = [
+    {
+        type: 'function',
+        inputs: [
+            { name: 'destination', internalType: 'address', type: 'address' },
+            { name: 'payload', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'DelegateCallVoucher',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [{ name: 'payload', internalType: 'bytes', type: 'bytes' }],
+        name: 'Notice',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            { name: 'destination', internalType: 'address', type: 'address' },
+            { name: 'value', internalType: 'uint256', type: 'uint256' },
+            { name: 'payload', internalType: 'bytes', type: 'bytes' },
+        ],
+        name: 'Voucher',
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+] as const

--- a/packages/viem/README.md
+++ b/packages/viem/README.md
@@ -24,8 +24,7 @@ The following methods are provided to interact with the Cartesi Rollups Node.
 
 ## L1 operations
 
-Transactions related to Cartesi applications are sent directly to the base layer (L1).
-Those are regular contract interactions, best served by viem's own [contract actions](https://viem.sh/docs/contract/writeContract) combined with the typed ABIs and deployment addresses exported by `@cartesi/viem/abi`:
+Direct inputs such as deposits are sent to the base layer (L1). Those are regular contract interactions, best served by viem's own [contract actions](https://viem.sh/docs/contract/writeContract) combined with the typed ABIs and deployment addresses exported by `@cartesi/viem/abi`:
 
 ```typescript
 import { inputBoxAbi, inputBoxAddress } from "@cartesi/viem/abi";
@@ -39,6 +38,41 @@ const hash = await walletClient.writeContract({
 ```
 
 Users of [wagmi](https://wagmi.sh) can use the generated actions and React hooks from `@cartesi/wagmi`, or generate their own code using the `@cartesi/wagmi-plugin` plugin for `@wagmi/cli`.
+
+## Sequencer transactions
+
+Application transactions can be signed as EIP-712 `UserOp` messages and sent through a dedicated Cartesi sequencer client. For injected wallets such as MetaMask, pass a Wallet Client that the sequencer client can use only for signing:
+
+```typescript
+import { createSequencerClient } from "@cartesi/viem/sequencer";
+import { createWalletClient, custom, http, stringToHex } from "viem";
+import { foundry } from "viem/chains";
+
+const [account] = await window.ethereum.request({
+    method: "eth_requestAccounts",
+});
+const walletClient = createWalletClient({
+    chain: foundry,
+    transport: custom(window.ethereum),
+});
+const sequencerClient = createSequencerClient({
+    account,
+    application: "0x1111111111111111111111111111111111111111",
+    chain: foundry,
+    transport: http("http://127.0.0.1:3000"),
+    walletClient,
+});
+
+const confirmation = await sequencerClient.sendTransaction({
+    data: stringToHex("hello"), // application-defined SSZ method payload
+    maxFee: 1200, // uint16 log-space fee exponent
+    nonce: 0, // uint32 application nonce
+});
+```
+
+For a local viem account, pass the account directly and omit `walletClient`. `sendTransaction` signs with the sequencer's canonical EIP-712 domain (`CartesiAppSequencer`, version `1`, the configured chain id and application address), submits to `POST /tx`, and resolves after the sequencer returns its soft confirmation. `signTransaction` and `submitTransaction` are also available when signing and submission need to happen separately.
+
+The sequencer currently does not expose nonce or fee-discovery endpoints. Applications should obtain those values from their application state or indexer. Submission is not retried automatically because a timed-out request may already have been committed.
 
 ## Utilities
 

--- a/packages/viem/__tests__/sequencer.test.ts
+++ b/packages/viem/__tests__/sequencer.test.ts
@@ -1,0 +1,273 @@
+import {
+    createWalletClient,
+    custom,
+    getAddress,
+    http,
+    recoverTypedDataAddress,
+    stringToHex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { foundry, mainnet } from "viem/chains";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    type SequencerTransactionRejectedError,
+    createSequencerClient,
+    sequencerDomainName,
+    sequencerDomainVersion,
+    sequencerTransactionTypes,
+    signSequencerTransaction,
+} from "../src/index.js";
+
+const account = privateKeyToAccount(
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+);
+const application = "0x1111111111111111111111111111111111111111";
+
+const createClient = () =>
+    createSequencerClient({
+        account,
+        application,
+        chain: foundry,
+        transport: http("http://127.0.0.1:3000"),
+    });
+
+const typedData = {
+    domain: {
+        chainId: foundry.id,
+        name: sequencerDomainName,
+        verifyingContract: application,
+        version: sequencerDomainVersion,
+    },
+    message: { data: "0x1234", max_fee: 1200, nonce: 0 },
+    primaryType: "UserOp",
+    types: sequencerTransactionTypes,
+} as const;
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("sequencer client", () => {
+    it("signs the canonical sequencer UserOp EIP-712 type locally", async () => {
+        const client = createClient();
+        const transaction = await client.signTransaction({
+            data: stringToHex("hello"),
+            maxFee: 1200,
+            nonce: 7,
+        });
+
+        expect(client.type).toBe("sequencerClient");
+        expect(client.application).toBe(application);
+        expect(transaction.message).toEqual({
+            data: stringToHex("hello"),
+            max_fee: 1200,
+            nonce: 7,
+        });
+        expect(transaction.sender).toBe(account.address);
+        await expect(
+            recoverTypedDataAddress({
+                domain: typedData.domain,
+                message: transaction.message,
+                primaryType: typedData.primaryType,
+                signature: transaction.signature,
+                types: typedData.types,
+            }),
+        ).resolves.toBe(account.address);
+
+        await expect(
+            signSequencerTransaction(client, {
+                data: "0x",
+                maxFee: 1200,
+                nonce: 8,
+            }),
+        ).resolves.toMatchObject({ sender: account.address });
+    });
+
+    it("signs and submits a transaction to POST /tx", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    nonce: 0,
+                    ok: true,
+                    sender: account.address.toLowerCase(),
+                }),
+                {
+                    headers: { "content-type": "application/json" },
+                    status: 200,
+                },
+            ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const receipt = await createClient().sendTransaction({
+            data: "0x1234",
+            maxFee: 1200,
+            nonce: 0,
+        });
+
+        expect(receipt).toEqual({
+            nonce: 0,
+            ok: true,
+            sender: getAddress(account.address),
+        });
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("http://127.0.0.1:3000/tx");
+        expect(init.method).toBe("POST");
+        expect(new Headers(init.headers).get("content-type")).toBe(
+            "application/json",
+        );
+
+        const body = JSON.parse(init.body as string);
+        expect(body).toMatchObject({
+            message: { data: "0x1234", max_fee: 1200, nonce: 0 },
+            sender: account.address,
+        });
+        expect(body.signature).toMatch(/^0x[0-9a-f]{130}$/);
+    });
+
+    it("supports separate signing and submission", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        nonce: 0,
+                        ok: true,
+                        sender: account.address,
+                    }),
+                    { status: 200 },
+                ),
+            ),
+        );
+        const client = createClient();
+        const transaction = await client.signTransaction({
+            data: "0x1234",
+            maxFee: 1200,
+            nonce: 0,
+        });
+
+        await expect(
+            client.submitTransaction({ transaction }),
+        ).resolves.toMatchObject({ ok: true, sender: account.address });
+    });
+
+    it("exposes structured sequencer rejection errors", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        code: "OVERLOADED",
+                        message: "queue full",
+                        ok: false,
+                    }),
+                    { status: 429 },
+                ),
+            ),
+        );
+
+        const promise = createClient().sendTransaction({
+            data: "0x",
+            maxFee: 1200,
+            nonce: 0,
+        });
+
+        await expect(promise).rejects.toMatchObject({
+            code: "OVERLOADED",
+            details: "queue full",
+            name: "SequencerTransactionRejectedError",
+            status: 429,
+        } satisfies Partial<SequencerTransactionRejectedError>);
+    });
+
+    it("rejects values that do not fit the protocol integer widths", async () => {
+        const client = createClient();
+
+        await expect(
+            client.signTransaction({ data: "0x", maxFee: 65_536, nonce: 0 }),
+        ).rejects.toThrow("maxFee must be an integer between 0 and 65535");
+        await expect(
+            client.signTransaction({ data: "0x", maxFee: 0, nonce: -1 }),
+        ).rejects.toThrow("nonce must be an integer between 0 and 4294967295");
+    });
+
+    it("signs through a MetaMask-compatible EIP-1193 Wallet Client", async () => {
+        const signature = await account.signTypedData(typedData);
+        const request = vi.fn().mockResolvedValue(signature);
+        const walletClient = createWalletClient({
+            chain: foundry,
+            transport: custom({ request }),
+        });
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        nonce: 0,
+                        ok: true,
+                        sender: account.address,
+                    }),
+                    { status: 200 },
+                ),
+            ),
+        );
+        const client = createSequencerClient({
+            account: account.address,
+            application,
+            chain: foundry,
+            transport: http("http://127.0.0.1:3000"),
+            walletClient,
+        });
+
+        const receipt = await client.sendTransaction({
+            data: "0x1234",
+            maxFee: 1200,
+            nonce: 0,
+        });
+
+        expect(receipt).toMatchObject({
+            nonce: 0,
+            ok: true,
+            sender: account.address,
+        });
+        expect(request.mock.calls[0]?.[0]).toEqual(
+            expect.objectContaining({ method: "eth_signTypedData_v4" }),
+        );
+    });
+
+    it("requires a Wallet Client for JSON-RPC accounts", async () => {
+        const client = createSequencerClient({
+            account: account.address,
+            application,
+            chain: foundry,
+            transport: http("http://127.0.0.1:3000"),
+        });
+
+        await expect(
+            client.signTransaction({ data: "0x", maxFee: 1200, nonce: 0 }),
+        ).rejects.toThrow(
+            "walletClient is required to sign with a JSON-RPC account",
+        );
+    });
+
+    it("rejects a Wallet Client configured for another chain", () => {
+        const walletClient = createWalletClient({
+            chain: mainnet,
+            transport: custom({ request: vi.fn() }),
+        });
+
+        expect(() =>
+            createSequencerClient({
+                account: account.address,
+                application,
+                // @ts-expect-error Verify the runtime guard for JavaScript callers.
+                chain: foundry,
+                transport: http("http://127.0.0.1:3000"),
+                walletClient,
+            }),
+        ).toThrow(
+            "walletClient chain id 1 does not match sequencer chain id 31337",
+        );
+    });
+});

--- a/packages/viem/examples/sequencer.ts
+++ b/packages/viem/examples/sequencer.ts
@@ -1,0 +1,118 @@
+import { erc20PortalAbi } from "@cartesi/viem/abi";
+import { createSequencerClient } from "@cartesi/viem/sequencer";
+import {
+    createPublicClient,
+    createTestClient,
+    createWalletClient,
+    http,
+    parseAbi,
+    parseUnits,
+} from "viem";
+import { mnemonicToAccount } from "viem/accounts";
+import { anvil } from "viem/chains";
+
+// devnet erc20 portal address
+const erc20PortalAddress = "0xACA6586A0Cf05bD831f2501E7B4aea550dA6562D";
+
+// sequencer devnet application address
+const application = "0x7508F403A38a0cE53ca70F3DC4c150d614CE371C";
+
+// sequencer devnet application address
+const mnemonic = "test test test test test test test test test test test junk";
+const addressIndex = 3;
+
+// sequencer devnet RPC URL
+const rpcUrl = "http://127.0.0.1:51872";
+
+// sequencer devnet URL
+const sequencerUrl = "http://127.0.0.1:51887";
+
+// tx data
+const data = "0xdeadbeef";
+const maxFee = 1_200;
+const nonce = 0;
+
+// create an L1 wallet client
+const account = mnemonicToAccount(mnemonic, { addressIndex });
+const walletClient = createWalletClient({
+    account,
+    chain: anvil,
+    transport: http(rpcUrl),
+});
+
+// create a separate client for the sequencer service
+const sequencerClient = createSequencerClient({
+    account,
+    application,
+    chain: anvil,
+    transport: http(sequencerUrl),
+});
+
+const publicClient = createPublicClient({
+    chain: anvil,
+    transport: http(rpcUrl),
+});
+
+// fee token
+const mockUsdc = "0x95d0c8A7d11342299807A2Fc19ac44C2321cCc68";
+
+const mockUsdcAbi = parseAbi([
+    "function approve(address spender, uint256 value) returns (bool)",
+    "function balanceOf(address) view returns (uint256)",
+    "function mint(address to, uint256 value)",
+]);
+
+const amount = parseUnits("10", 6); // 10 USDC
+
+// Local devnet only: mint mock USDC.
+const mintHash = await walletClient.writeContract({
+    address: mockUsdc,
+    abi: mockUsdcAbi,
+    functionName: "mint",
+    args: [account.address, amount],
+});
+console.log(
+    `Minting ${amount} mock USDC to ${account.address}, tx hash: ${mintHash}`,
+);
+await publicClient.waitForTransactionReceipt({ hash: mintHash });
+
+// Allow ERC20Portal to transfer it.
+const approveHash = await walletClient.writeContract({
+    address: mockUsdc,
+    abi: mockUsdcAbi,
+    functionName: "approve",
+    args: [erc20PortalAddress, amount],
+});
+console.log(
+    `Approving ${amount} mock USDC for ERC20Portal, tx hash: ${approveHash}`,
+);
+await publicClient.waitForTransactionReceipt({ hash: approveHash });
+
+// Deposit into the application.
+const depositHash = await walletClient.writeContract({
+    address: erc20PortalAddress,
+    abi: erc20PortalAbi,
+    functionName: "depositERC20Tokens",
+    args: [mockUsdc, application, amount, "0x"],
+});
+console.log(
+    `Depositing ${amount} mock USDC into the application, tx hash: ${depositHash}`,
+);
+await publicClient.waitForTransactionReceipt({ hash: depositHash });
+
+// Give the sequencer another safe L1 block to observe the direct input.
+const testClient = createTestClient({
+    chain: anvil,
+    mode: "anvil",
+    transport: http(rpcUrl),
+});
+await testClient.mine({ blocks: 10 }); // why 3? 1 did not work
+
+console.log(`Sending sequencer transaction with data: ${data}`);
+const receipt = await sequencerClient.sendTransaction({
+    data,
+    maxFee,
+    nonce,
+});
+
+console.log(receipt);

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -66,6 +66,16 @@
                 "types": "./dist/chains.d.cts",
                 "require": "./dist/chains.cjs"
             }
+        },
+        "./sequencer": {
+            "import": {
+                "types": "./dist/sequencer/index.d.ts",
+                "import": "./dist/sequencer/index.js"
+            },
+            "require": {
+                "types": "./dist/sequencer/index.d.cts",
+                "require": "./dist/sequencer/index.cjs"
+            }
         }
     },
     "files": [

--- a/packages/viem/src/clients/createSequencerClient.ts
+++ b/packages/viem/src/clients/createSequencerClient.ts
@@ -1,0 +1,122 @@
+import {
+    type Account,
+    type Address,
+    type Chain,
+    type Client,
+    type ClientConfig,
+    type HttpTransport,
+    type ParseAccount,
+    type Prettify,
+    type Transport,
+    type WalletClient,
+    createClient,
+} from "viem";
+import {
+    sendSequencerTransaction,
+    signSequencerTransaction,
+    submitSequencerTransaction,
+} from "../sequencer/actions.js";
+import type {
+    SequencerActions,
+    SequencerTransactionParameters,
+    SubmitSequencerTransactionParameters,
+} from "../sequencer/types.js";
+
+export type SequencerClientConfig<
+    transport extends HttpTransport = HttpTransport,
+    chain extends Chain = Chain,
+    accountOrAddress extends Account | Address = Account | Address,
+    walletTransport extends Transport = Transport,
+    walletAccount extends Account | undefined = Account | undefined,
+> = Prettify<
+    Omit<
+        ClientConfig<transport, chain, accountOrAddress>,
+        "account" | "chain" | "transport" | "type"
+    > & {
+        /** Account used to sign EIP-712 user operations. */
+        account: accountOrAddress;
+        /** Application address used as the EIP-712 verifying contract. */
+        application: Address;
+        /** L1 chain whose id is included in the EIP-712 domain. */
+        chain: chain;
+        /** Viem HTTP transport pointed at the sequencer API. */
+        transport: transport;
+        /** Wallet Client used to sign for a JSON-RPC account such as MetaMask. */
+        walletClient?:
+            | WalletClient<walletTransport, chain, walletAccount>
+            | undefined;
+    }
+>;
+
+export type SequencerClient<
+    transport extends HttpTransport = HttpTransport,
+    chain extends Chain = Chain,
+    accountOrAddress extends Account | Address = Account | Address,
+    walletTransport extends Transport = Transport,
+    walletAccount extends Account | undefined = Account | undefined,
+> = Prettify<
+    Client<transport, chain, ParseAccount<accountOrAddress>> &
+        SequencerActions & {
+            application: Address;
+            walletClient?:
+                | WalletClient<walletTransport, chain, walletAccount>
+                | undefined;
+        }
+>;
+
+export const createSequencerClient = <
+    transport extends HttpTransport,
+    chain extends Chain,
+    accountOrAddress extends Account | Address,
+    walletTransport extends Transport = Transport,
+    walletAccount extends Account | undefined = Account | undefined,
+>(
+    parameters: SequencerClientConfig<
+        transport,
+        chain,
+        accountOrAddress,
+        walletTransport,
+        walletAccount
+    >,
+): SequencerClient<
+    transport,
+    chain,
+    accountOrAddress,
+    walletTransport,
+    walletAccount
+> => {
+    const { application, walletClient, ...clientParameters } = parameters;
+    if (
+        walletClient?.chain &&
+        walletClient.chain.id !== clientParameters.chain.id
+    ) {
+        throw new TypeError(
+            `walletClient chain id ${walletClient.chain.id} does not match sequencer chain id ${clientParameters.chain.id}`,
+        );
+    }
+    const client = createClient({
+        ...clientParameters,
+        key: parameters.key ?? "sequencer",
+        name: parameters.name ?? "Cartesi Sequencer Client",
+        type: "sequencerClient",
+    });
+    const actionClient = Object.assign(client, {
+        application,
+        walletClient,
+    });
+
+    return Object.assign(actionClient, {
+        sendTransaction: (parameters: SequencerTransactionParameters) =>
+            sendSequencerTransaction(actionClient, parameters),
+        signTransaction: (parameters: SequencerTransactionParameters) =>
+            signSequencerTransaction(actionClient, parameters),
+        submitTransaction: (parameters: SubmitSequencerTransactionParameters) =>
+            submitSequencerTransaction(actionClient, parameters),
+    }) as SequencerClient<
+        transport,
+        chain,
+        accountOrAddress,
+        walletTransport,
+        walletAccount
+    >;
+};

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -4,6 +4,7 @@ export {
     type CartesiPublicClient,
 } from "./clients/createCartesiPublicClient.js";
 export { publicActionsL2 } from "./decorators/publicL2.js";
+export * from "./sequencer/index.js";
 export * from "./types/actions.js";
 export { type OutputArgs, toOutputArgs } from "./types/output.js";
 export * from "./utils/index.js";

--- a/packages/viem/src/sequencer/actions.ts
+++ b/packages/viem/src/sequencer/actions.ts
@@ -1,0 +1,226 @@
+import {
+    type Account,
+    type Chain,
+    type Client,
+    type HttpTransport,
+    type Transport,
+    getAddress,
+    isAddress,
+    isHex,
+} from "viem";
+import { signTypedData } from "viem/actions";
+import {
+    sequencerDomainName,
+    sequencerDomainVersion,
+    sequencerTransactionTypes,
+} from "./constants.js";
+import {
+    SequencerRequestError,
+    SequencerResponseError,
+    SequencerTransactionRejectedError,
+} from "./errors.js";
+import type {
+    SequencerErrorResponse,
+    SequencerTransactionReceipt,
+    SequencerTransactionParameters,
+    SignSequencerTransactionParameters,
+    SignedSequencerTransaction,
+    SubmitSequencerTransactionParameters,
+} from "./types.js";
+
+type SequencerActionClient<
+    transport extends HttpTransport = HttpTransport,
+    chain extends Chain = Chain,
+    account extends Account = Account,
+> = Client<transport, chain, account> & {
+    application: `0x${string}`;
+    walletClient?: object | undefined;
+};
+
+const assertUnsignedInteger = (
+    value: number,
+    maximum: number,
+    name: string,
+) => {
+    if (!Number.isInteger(value) || value < 0 || value > maximum) {
+        throw new RangeError(
+            `${name} must be an integer between 0 and ${maximum}`,
+        );
+    }
+};
+
+export const signSequencerTransaction = async <
+    transport extends HttpTransport,
+    chain extends Chain,
+    clientAccount extends Account,
+>(
+    client: SequencerActionClient<transport, chain, clientAccount>,
+    parameters: SignSequencerTransactionParameters,
+): Promise<SignedSequencerTransaction> => {
+    const { data, maxFee, nonce } = parameters;
+    const accountValue = parameters.account ?? client.account;
+    const account =
+        typeof accountValue === "string"
+            ? ({
+                  address: getAddress(accountValue),
+                  type: "json-rpc",
+              } as const)
+            : accountValue;
+
+    assertUnsignedInteger(nonce, 0xffff_ffff, "nonce");
+    assertUnsignedInteger(maxFee, 0xffff, "maxFee");
+    if (!isHex(data))
+        throw new TypeError("data must be a 0x-prefixed hex value");
+    const canSignLocally =
+        "signTypedData" in account &&
+        typeof account.signTypedData === "function";
+    if (!canSignLocally && !client.walletClient) {
+        throw new TypeError(
+            "walletClient is required to sign with a JSON-RPC account",
+        );
+    }
+
+    const message = { data, max_fee: maxFee, nonce };
+    const signingClient = (client.walletClient ?? client) as Client<
+        Transport,
+        Chain,
+        Account | undefined
+    >;
+    const signature = await signTypedData(signingClient, {
+        account,
+        domain: {
+            chainId: client.chain.id,
+            name: sequencerDomainName,
+            verifyingContract: client.application,
+            version: sequencerDomainVersion,
+        },
+        message,
+        primaryType: "UserOp",
+        types: sequencerTransactionTypes,
+    });
+
+    return {
+        message,
+        sender: account.address,
+        signature,
+    };
+};
+
+const isErrorResponse = (value: unknown): value is SequencerErrorResponse => {
+    if (!value || typeof value !== "object") return false;
+    const response = value as Record<string, unknown>;
+    return (
+        response.ok === false &&
+        typeof response.code === "string" &&
+        typeof response.message === "string"
+    );
+};
+
+const isSuccessResponse = (
+    value: unknown,
+): value is SequencerTransactionReceipt => {
+    if (!value || typeof value !== "object") return false;
+    const response = value as Record<string, unknown>;
+    return (
+        response.ok === true &&
+        typeof response.nonce === "number" &&
+        typeof response.sender === "string" &&
+        isAddress(response.sender)
+    );
+};
+
+export const submitSequencerTransaction = async <
+    transport extends HttpTransport,
+    chain extends Chain,
+    account extends Account,
+>(
+    client: SequencerActionClient<transport, chain, account>,
+    { transaction }: SubmitSequencerTransactionParameters,
+): Promise<SequencerTransactionReceipt> => {
+    const baseUrl = client.transport.url;
+    if (!baseUrl) {
+        throw new TypeError(
+            'sequencer HTTP transport requires an explicit URL: http("...")',
+        );
+    }
+
+    const url = `${baseUrl.replace(/\/$/, "")}/tx`;
+    const fetchOptions = client.transport.fetchOptions;
+    const headers = new Headers(fetchOptions?.headers);
+    headers.set("content-type", "application/json");
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            ...fetchOptions,
+            body: JSON.stringify(transaction),
+            headers,
+            method: "POST",
+            signal:
+                fetchOptions?.signal ??
+                AbortSignal.timeout(client.transport.timeout ?? 10_000),
+        });
+    } catch (error) {
+        throw new SequencerRequestError({
+            cause: error instanceof Error ? error : undefined,
+            url,
+        });
+    }
+
+    let body: string;
+    try {
+        body = await response.text();
+    } catch (error) {
+        throw new SequencerRequestError({
+            cause: error instanceof Error ? error : undefined,
+            url,
+        });
+    }
+    let json: unknown;
+    try {
+        json = JSON.parse(body);
+    } catch {
+        throw new SequencerResponseError({
+            body,
+            status: response.status,
+            url,
+        });
+    }
+
+    if (!response.ok) {
+        if (isErrorResponse(json)) {
+            throw new SequencerTransactionRejectedError({
+                body: json,
+                status: response.status,
+                url,
+            });
+        }
+        throw new SequencerResponseError({
+            body,
+            status: response.status,
+            url,
+        });
+    }
+
+    if (!isSuccessResponse(json)) {
+        throw new SequencerResponseError({
+            body,
+            status: response.status,
+            url,
+        });
+    }
+
+    return { ...json, sender: getAddress(json.sender) };
+};
+
+export const sendSequencerTransaction = async <
+    transport extends HttpTransport,
+    chain extends Chain,
+    account extends Account,
+>(
+    client: SequencerActionClient<transport, chain, account>,
+    parameters: SequencerTransactionParameters,
+): Promise<SequencerTransactionReceipt> => {
+    const transaction = await signSequencerTransaction(client, parameters);
+    return submitSequencerTransaction(client, { transaction });
+};

--- a/packages/viem/src/sequencer/constants.ts
+++ b/packages/viem/src/sequencer/constants.ts
@@ -1,0 +1,10 @@
+export const sequencerDomainName = "CartesiAppSequencer";
+export const sequencerDomainVersion = "1";
+
+export const sequencerTransactionTypes = {
+    UserOp: [
+        { name: "nonce", type: "uint32" },
+        { name: "max_fee", type: "uint16" },
+        { name: "data", type: "bytes" },
+    ],
+} as const;

--- a/packages/viem/src/sequencer/errors.ts
+++ b/packages/viem/src/sequencer/errors.ts
@@ -1,0 +1,75 @@
+import { BaseError } from "viem";
+import type { SequencerErrorCode, SequencerErrorResponse } from "./types.js";
+
+export class SequencerRequestError extends BaseError {
+    override name = "SequencerRequestError";
+    url: string;
+
+    constructor({ cause, url }: { cause?: Error | undefined; url: string }) {
+        super("Sequencer request failed.", {
+            cause,
+            details: cause?.message,
+            metaMessages: [`URL: ${url}`],
+            name: "SequencerRequestError",
+        });
+        this.url = url;
+    }
+}
+
+export class SequencerResponseError extends BaseError {
+    override name = "SequencerResponseError";
+    body: string;
+    status: number;
+    url: string;
+
+    constructor({
+        body,
+        status,
+        url,
+    }: {
+        body: string;
+        status: number;
+        url: string;
+    }) {
+        super("Sequencer returned an invalid response.", {
+            details: body || `HTTP ${status}`,
+            metaMessages: [`Status: ${status}`, `URL: ${url}`],
+            name: "SequencerResponseError",
+        });
+        this.body = body;
+        this.status = status;
+        this.url = url;
+    }
+}
+
+export class SequencerTransactionRejectedError extends BaseError {
+    override name = "SequencerTransactionRejectedError";
+    body: SequencerErrorResponse;
+    code: SequencerErrorCode | (string & {});
+    status: number;
+    url: string;
+
+    constructor({
+        body,
+        status,
+        url,
+    }: {
+        body: SequencerErrorResponse;
+        status: number;
+        url: string;
+    }) {
+        super("Sequencer transaction was rejected.", {
+            details: body.message,
+            metaMessages: [
+                `Code: ${body.code}`,
+                `Status: ${status}`,
+                `URL: ${url}`,
+            ],
+            name: "SequencerTransactionRejectedError",
+        });
+        this.body = body;
+        this.code = body.code;
+        this.status = status;
+        this.url = url;
+    }
+}

--- a/packages/viem/src/sequencer/index.ts
+++ b/packages/viem/src/sequencer/index.ts
@@ -1,0 +1,21 @@
+export {
+    sendSequencerTransaction,
+    signSequencerTransaction,
+    submitSequencerTransaction,
+} from "./actions.js";
+export {
+    createSequencerClient,
+    type SequencerClient,
+    type SequencerClientConfig,
+} from "../clients/createSequencerClient.js";
+export {
+    sequencerDomainName,
+    sequencerDomainVersion,
+    sequencerTransactionTypes,
+} from "./constants.js";
+export {
+    SequencerRequestError,
+    SequencerResponseError,
+    SequencerTransactionRejectedError,
+} from "./errors.js";
+export type * from "./types.js";

--- a/packages/viem/src/sequencer/types.ts
+++ b/packages/viem/src/sequencer/types.ts
@@ -1,0 +1,66 @@
+import type { Account, Address, Hex } from "viem";
+
+export type SequencerTransaction = {
+    /** Application-defined SSZ-encoded method payload. */
+    data: Hex;
+    /** Maximum fee, encoded as the sequencer protocol's uint16 exponent. */
+    maxFee: number;
+    /** Sender nonce. */
+    nonce: number;
+};
+
+export type SequencerTransactionMessage = {
+    data: Hex;
+    max_fee: number;
+    nonce: number;
+};
+
+export type SignedSequencerTransaction = {
+    message: SequencerTransactionMessage;
+    sender: Address;
+    signature: Hex;
+};
+
+export type SequencerTransactionReceipt = {
+    nonce: number;
+    ok: true;
+    sender: Address;
+};
+
+export type SequencerErrorCode =
+    | "BAD_REQUEST"
+    | "EXECUTION_REJECTED"
+    | "INTERNAL_ERROR"
+    | "INVALID_SIGNATURE"
+    | "OVERLOADED"
+    | "PAYLOAD_TOO_LARGE"
+    | "UNAVAILABLE";
+
+export type SequencerErrorResponse = {
+    code: SequencerErrorCode | (string & {});
+    message: string;
+    ok: false;
+};
+
+export type SequencerTransactionParameters = SequencerTransaction & {
+    /** Account override. Defaults to the client's account. */
+    account?: Account | Address | undefined;
+};
+
+export type SignSequencerTransactionParameters = SequencerTransactionParameters;
+
+export type SubmitSequencerTransactionParameters = {
+    transaction: SignedSequencerTransaction;
+};
+
+export type SequencerActions = {
+    sendTransaction: (
+        parameters: SequencerTransactionParameters,
+    ) => Promise<SequencerTransactionReceipt>;
+    signTransaction: (
+        parameters: SequencerTransactionParameters,
+    ) => Promise<SignedSequencerTransaction>;
+    submitTransaction: (
+        parameters: SubmitSequencerTransactionParameters,
+    ) => Promise<SequencerTransactionReceipt>;
+};

--- a/packages/viem/tsdown.config.ts
+++ b/packages/viem/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         "src/chains.ts",
         "src/index.ts",
         "src/rollups.ts",
+        "src/sequencer/index.ts",
     ],
     fixedExtension: false,
     format: ["cjs", "esm"],


### PR DESCRIPTION
## Summary

- Add `@cartesi/viem/sequencer`, a viem Wallet Client extension for EIP-712 signed Cartesi sequencer transactions
- Provide `sendSequencerTransaction`, `signSequencerTransaction`, and `submitSequencerTransaction` actions for combined and split sign/submit flows
- Support both JSON-RPC accounts such as MetaMask and viem local accounts through viem's `signTypedData` action
- Validate transaction fields and expose structured request, response, and sequencer rejection errors
- Export the sequencer entrypoint in both ESM and CommonJS builds and add a release changeset
- Document browser-wallet and local-account setup, action semantics, EIP-712 fields, configuration, errors, and retry considerations

## Testing

- Biome checks pass
- TypeScript checks pass
- Sequencer test suite passes (9 tests), including the MetaMask/EIP-1193 signing path
- ESM and CommonJS builds pass, including package export smoke checks
- Vocs production documentation build passes
