### PR TITLE
feat(codec): byte array support with zero-copy decoding

### DIFF
--- a/.changeset/spotty-panthers-decode.md
+++ b/.changeset/spotty-panthers-decode.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/codec": minor
+---
+
+Support byte arrays alongside hex strings in all codec functions. Decode functions (`decodeInput`, `decodeOutput`, `decodeDeposit` and the portal deposit decoders) now also accept a `Uint8Array` (including subclasses like the Node.js `Buffer`), returning variable-size byte fields (`payload`, `execLayerData`, `baseLayerData`) as zero-copy subarrays of the input — no hex conversion or copying. Encode functions take an optional `to` parameter (`"hex"`, the default, or `"bytes"`) selecting the representation of the encoded data, and accept their byte fields in either representation. Hex in, hex out behavior is unchanged.

--- a/apps/docs/pages/codec/decodeDeposit.mdx
+++ b/apps/docs/pages/codec/decodeDeposit.mdx
@@ -37,11 +37,13 @@ if (deposit) {
 
 ## Parameters
 
-- `input`: a decoded input — only the `msgSender` and `payload` fields are used.
+- `input`: a decoded input — only the `msgSender` and `payload` fields are used. The `payload` may be a `Hex` string or a `Uint8Array`.
 
 ## Return Type
 
 A `Deposit` union discriminated by the `type` field (`"EtherDeposit"`, `"Erc20Deposit"`, `"Erc721Deposit"`, `"Erc1155SingleDeposit"` or `"Erc1155BatchDeposit"`), where each variant carries the fields of the corresponding deposit type.
+
+Byte fields follow the representation of the `payload`: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the payload — no data is copied.
 
 Returns `undefined` if `msgSender` is not a portal, i.e. the input is not a deposit.
 

--- a/apps/docs/pages/codec/decodeErc1155BatchDeposit.mdx
+++ b/apps/docs/pages/codec/decodeErc1155BatchDeposit.mdx
@@ -23,7 +23,7 @@ const deposit = decodeErc1155BatchDeposit(input.payload);
 
 ## Parameters
 
-- `payload` (`Hex`): packed-encoded deposit payload (the `payload` field of a decoded input).
+- `payload` (`Hex | Uint8Array`): packed-encoded deposit payload (the `payload` field of a decoded input).
 
 ## Return Type
 
@@ -33,10 +33,12 @@ A `Erc1155BatchDeposit` object:
 - `sender` (`Address`): token sender.
 - `tokenIds` (`readonly bigint[]`): identifiers of the tokens being transferred.
 - `values` (`readonly bigint[]`): transfer amounts per token type.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeErc1155SingleDeposit.mdx
+++ b/apps/docs/pages/codec/decodeErc1155SingleDeposit.mdx
@@ -23,7 +23,7 @@ const deposit = decodeErc1155SingleDeposit(input.payload);
 
 ## Parameters
 
-- `payload` (`Hex`): packed-encoded deposit payload (the `payload` field of a decoded input).
+- `payload` (`Hex | Uint8Array`): packed-encoded deposit payload (the `payload` field of a decoded input).
 
 ## Return Type
 
@@ -33,10 +33,12 @@ A `Erc1155SingleDeposit` object:
 - `sender` (`Address`): token sender.
 - `tokenId` (`bigint`): identifier of the token being transferred.
 - `value` (`bigint`): transfer amount.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeErc20Deposit.mdx
+++ b/apps/docs/pages/codec/decodeErc20Deposit.mdx
@@ -21,7 +21,7 @@ const deposit = decodeErc20Deposit(input.payload);
 
 ## Parameters
 
-- `payload` (`Hex`): packed-encoded deposit payload (the `payload` field of a decoded input).
+- `payload` (`Hex | Uint8Array`): packed-encoded deposit payload (the `payload` field of a decoded input).
 
 ## Return Type
 
@@ -30,9 +30,11 @@ An `Erc20Deposit` object:
 - `token` (`Address`): token contract.
 - `sender` (`Address`): token sender.
 - `value` (`bigint`): amount of tokens being sent.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeErc721Deposit.mdx
+++ b/apps/docs/pages/codec/decodeErc721Deposit.mdx
@@ -22,7 +22,7 @@ const deposit = decodeErc721Deposit(input.payload);
 
 ## Parameters
 
-- `payload` (`Hex`): packed-encoded deposit payload (the `payload` field of a decoded input).
+- `payload` (`Hex | Uint8Array`): packed-encoded deposit payload (the `payload` field of a decoded input).
 
 ## Return Type
 
@@ -31,10 +31,12 @@ An `Erc721Deposit` object:
 - `token` (`Address`): token contract.
 - `sender` (`Address`): token sender.
 - `tokenId` (`bigint`): token identifier.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeEtherDeposit.mdx
+++ b/apps/docs/pages/codec/decodeEtherDeposit.mdx
@@ -20,7 +20,7 @@ const deposit = decodeEtherDeposit(input.payload);
 
 ## Parameters
 
-- `payload` (`Hex`): packed-encoded deposit payload (the `payload` field of a decoded input).
+- `payload` (`Hex | Uint8Array`): packed-encoded deposit payload (the `payload` field of a decoded input).
 
 ## Return Type
 
@@ -28,9 +28,11 @@ An `EtherDeposit` object:
 
 - `sender` (`Address`): Ether sender.
 - `value` (`bigint`): amount of Wei being sent.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeInput.mdx
+++ b/apps/docs/pages/codec/decodeInput.mdx
@@ -24,7 +24,7 @@ const input = decodeInput(
 
 ## Parameters
 
-- `data` (`Hex`): ABI-encoded input data, starting with the `EvmAdvance` function selector (`0x415bf363`).
+- `data` (`Hex | Uint8Array`): ABI-encoded input data, starting with the `EvmAdvance` function selector (`0x415bf363`).
 
 ## Return Type
 
@@ -37,9 +37,11 @@ An `Input` object, with field names and types inferred from the `EvmAdvance` ABI
 - `blockTimestamp` (`bigint`): base layer block timestamp (in seconds) in which the input was added.
 - `prevRandao` (`bigint`): `prevrandao` value of the base layer block in which the input was added.
 - `index` (`bigint`): index of the input in the application input box.
-- `payload` (`Hex`): application-specific payload of the input.
+- `payload` (`Hex | Uint8Array`): application-specific payload of the input.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/decodeOutput.mdx
+++ b/apps/docs/pages/codec/decodeOutput.mdx
@@ -27,7 +27,7 @@ switch (output.type) {
 
 ## Parameters
 
-- `data` (`Hex`): ABI-encoded output data, starting with the selector of one of the `Outputs` functions: `Notice` (`0xc258d6e5`), `Voucher` (`0x237a816f`) or `DelegateCallVoucher` (`0x10321e8b`).
+- `data` (`Hex | Uint8Array`): ABI-encoded output data, starting with the selector of one of the `Outputs` functions: `Notice` (`0xc258d6e5`), `Voucher` (`0x237a816f`) or `DelegateCallVoucher` (`0x10321e8b`).
 
 ## Return Type
 
@@ -46,22 +46,24 @@ import type {
 `Notice` — informational statement that can be validated on the base layer, but not executed:
 
 - `type` (`"Notice"`)
-- `payload` (`Hex`): application-specific payload of the notice.
+- `payload` (`Hex | Uint8Array`): application-specific payload of the notice.
 
 `Voucher` — single-use permission to execute a `CALL` to a base layer contract on behalf of the application:
 
 - `type` (`"Voucher"`)
 - `destination` (`Address`): address of the contract to be called.
 - `value` (`bigint`): amount of Wei to be passed along the call.
-- `payload` (`Hex`): calldata of the call.
+- `payload` (`Hex | Uint8Array`): calldata of the call.
 
 `DelegateCallVoucher` — single-use permission to execute a `DELEGATECALL` to a base layer contract in the context of the application contract:
 
 - `type` (`"DelegateCallVoucher"`)
 - `destination` (`Address`): address of the contract to be delegate-called.
-- `payload` (`Hex`): calldata of the delegate call.
+- `payload` (`Hex | Uint8Array`): calldata of the delegate call.
 
 Addresses are returned checksummed.
+
+Byte fields follow the representation of the encoded data: hex string in, hex string out; byte array in, byte array out. When decoding from a `Uint8Array`, the returned byte fields are zero-copy subarrays of the input — no data is copied.
 
 ## Errors
 

--- a/apps/docs/pages/codec/encodeDelegateCallVoucher.mdx
+++ b/apps/docs/pages/codec/encodeDelegateCallVoucher.mdx
@@ -17,8 +17,14 @@ const data = encodeDelegateCallVoucher({
 ## Parameters
 
 - `destination` (`Address`): address of the contract to be delegate-called.
-- `payload` (`Hex`): calldata of the delegate call.
+- `payload` (`Hex | Uint8Array`): calldata of the delegate call.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: ABI-encoded output data, starting with the `DelegateCallVoucher` function selector (`0x10321e8b`).
+`Hex | Uint8Array`: ABI-encoded output data, starting with the `DelegateCallVoucher` function selector (`0x10321e8b`).
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeErc1155BatchDeposit.mdx
+++ b/apps/docs/pages/codec/encodeErc1155BatchDeposit.mdx
@@ -25,9 +25,15 @@ A `Erc1155BatchDeposit` object:
 - `sender` (`Address`): token sender.
 - `tokenIds` (`readonly bigint[]`): identifiers of the tokens being transferred.
 - `values` (`readonly bigint[]`): transfer amounts per token type.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ abi.encode(tokenIds, values, baseLayerData, execLayerData)`.
+`Hex | Uint8Array`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ abi.encode(tokenIds, values, baseLayerData, execLayerData)`.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeErc1155SingleDeposit.mdx
+++ b/apps/docs/pages/codec/encodeErc1155SingleDeposit.mdx
@@ -25,9 +25,15 @@ A `Erc1155SingleDeposit` object:
 - `sender` (`Address`): token sender.
 - `tokenId` (`bigint`): identifier of the token being transferred.
 - `value` (`bigint`): transfer amount.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ tokenId (32 bytes) ‖ value (32 bytes) ‖ abi.encode(baseLayerData, execLayerData)`.
+`Hex | Uint8Array`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ tokenId (32 bytes) ‖ value (32 bytes) ‖ abi.encode(baseLayerData, execLayerData)`.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeErc20Deposit.mdx
+++ b/apps/docs/pages/codec/encodeErc20Deposit.mdx
@@ -23,8 +23,14 @@ An `Erc20Deposit` object:
 - `token` (`Address`): token contract.
 - `sender` (`Address`): token sender.
 - `value` (`bigint`): amount of tokens being sent.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ value (32 bytes) ‖ execLayerData`.
+`Hex | Uint8Array`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ value (32 bytes) ‖ execLayerData`.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeErc721Deposit.mdx
+++ b/apps/docs/pages/codec/encodeErc721Deposit.mdx
@@ -23,9 +23,15 @@ An `Erc721Deposit` object:
 - `token` (`Address`): token contract.
 - `sender` (`Address`): token sender.
 - `tokenId` (`bigint`): token identifier.
-- `baseLayerData` (`Hex`): additional data to be interpreted by the base layer.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `baseLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the base layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ tokenId (32 bytes) ‖ abi.encode(baseLayerData, execLayerData)`.
+`Hex | Uint8Array`: packed-encoded deposit payload, with layout `token (20 bytes) ‖ sender (20 bytes) ‖ tokenId (32 bytes) ‖ abi.encode(baseLayerData, execLayerData)`.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeEtherDeposit.mdx
+++ b/apps/docs/pages/codec/encodeEtherDeposit.mdx
@@ -21,8 +21,14 @@ An `EtherDeposit` object:
 
 - `sender` (`Address`): Ether sender.
 - `value` (`bigint`): amount of Wei being sent.
-- `execLayerData` (`Hex`): additional data to be interpreted by the execution layer.
+- `execLayerData` (`Hex | Uint8Array`): additional data to be interpreted by the execution layer.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: packed-encoded deposit payload, with layout `sender (20 bytes) ‖ value (32 bytes) ‖ execLayerData`.
+`Hex | Uint8Array`: packed-encoded deposit payload, with layout `sender (20 bytes) ‖ value (32 bytes) ‖ execLayerData`.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeInput.mdx
+++ b/apps/docs/pages/codec/encodeInput.mdx
@@ -31,8 +31,14 @@ An `Input` object, with field names and types inferred from the `EvmAdvance` ABI
 - `blockTimestamp` (`bigint`): base layer block timestamp (in seconds) in which the input was added.
 - `prevRandao` (`bigint`): `prevrandao` value of the base layer block in which the input was added.
 - `index` (`bigint`): index of the input in the application input box.
-- `payload` (`Hex`): application-specific payload of the input.
+- `payload` (`Hex | Uint8Array`): application-specific payload of the input.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: ABI-encoded input data, starting with the `EvmAdvance` function selector (`0x415bf363`).
+`Hex | Uint8Array`: ABI-encoded input data, starting with the `EvmAdvance` function selector (`0x415bf363`).
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeNotice.mdx
+++ b/apps/docs/pages/codec/encodeNotice.mdx
@@ -13,8 +13,14 @@ const data = encodeNotice({ payload: "0xdeadbeef" });
 
 ## Parameters
 
-- `payload` (`Hex`): application-specific payload of the notice.
+- `payload` (`Hex | Uint8Array`): application-specific payload of the notice.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: ABI-encoded output data, starting with the `Notice` function selector (`0xc258d6e5`).
+`Hex | Uint8Array`: ABI-encoded output data, starting with the `Notice` function selector (`0xc258d6e5`).
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeOutput.mdx
+++ b/apps/docs/pages/codec/encodeOutput.mdx
@@ -35,6 +35,12 @@ import type { Output } from "@cartesi/codec";
 // type Output = DelegateCallVoucher | Notice | Voucher;
 ```
 
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
+
 ## Return Type
 
-`Hex`: ABI-encoded output data.
+`Hex | Uint8Array`: ABI-encoded output data.
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/encodeVoucher.mdx
+++ b/apps/docs/pages/codec/encodeVoucher.mdx
@@ -19,8 +19,14 @@ const data = encodeVoucher({
 
 - `destination` (`Address`): address of the contract to be called.
 - `value` (`bigint`): amount of Wei to be passed along the call.
-- `payload` (`Hex`): calldata of the call.
+- `payload` (`Hex | Uint8Array`): calldata of the call.
+
+And an optional second parameter:
+
+- `to` (`"hex" | "bytes"`, optional): representation of the encoded data. Defaults to `"hex"`.
 
 ## Return Type
 
-`Hex`: ABI-encoded output data, starting with the `Voucher` function selector (`0x237a816f`).
+`Hex | Uint8Array`: ABI-encoded output data, starting with the `Voucher` function selector (`0x237a816f`).
+
+Returns a `Hex` string by default, or a `Uint8Array` when `to` is `"bytes"`.

--- a/apps/docs/pages/codec/index.mdx
+++ b/apps/docs/pages/codec/index.mdx
@@ -27,6 +27,29 @@ yarn add @cartesi/codec viem
 
 :::
 
+## Hex strings and byte arrays
+
+Every decode function accepts the encoded data as a `Hex` string or as a `Uint8Array` (including subclasses like the Node.js `Buffer`), and the variable-size byte fields of the result follow the representation of the input: hex in, hex out; bytes in, bytes out. When decoding from a `Uint8Array` the byte fields are returned as zero-copy subarrays of the input, so low-level bindings that already hold binary data (e.g. machine I/O) can decode without hex conversions or copies:
+
+```ts twoslash
+import { decodeInput } from "@cartesi/codec";
+
+declare const blob: Uint8Array; // e.g. straight from machine I/O
+
+const input = decodeInput(blob);
+input.payload; // Uint8Array, zero-copy view of `blob`
+```
+
+Every encode function takes an optional `to` parameter selecting the representation of the encoded data — `"hex"` (the default) or `"bytes"` — and accepts its byte fields in either representation:
+
+```ts twoslash
+import { encodeInput, decodeInput } from "@cartesi/codec";
+
+declare const blob: Uint8Array;
+
+const data = encodeInput(decodeInput(blob), "bytes"); // Uint8Array
+```
+
 ## Decode functions
 
 - [decodeInput](/codec/decodeInput) — decode an `EvmAdvance` input blob

--- a/packages/codec/__tests__/deposit.test.ts
+++ b/packages/codec/__tests__/deposit.test.ts
@@ -1,4 +1,4 @@
-import { getAddress } from "viem";
+import { getAddress, hexToBytes } from "viem";
 import { describe, expect, it } from "vitest";
 import {
     decodeDeposit,
@@ -126,5 +126,54 @@ describe("decodeDeposit", () => {
                 payload: "0xdeadbeef",
             }),
         ).toThrow("invalid Ether deposit payload");
+    });
+
+    it("should decode an Ether deposit input with a byte array payload", () => {
+        const deposit = {
+            sender,
+            value: 123456789n,
+            execLayerData: "0xdeadbeef",
+        } as const;
+        expect(
+            decodeDeposit({
+                msgSender: etherPortalAddress,
+                payload: encodeEtherDeposit(deposit, "bytes"),
+            }),
+        ).toEqual({
+            type: "EtherDeposit",
+            ...deposit,
+            execLayerData: hexToBytes("0xdeadbeef"),
+        });
+    });
+
+    it("should decode an ERC-1155 batch deposit input with a byte array payload", () => {
+        const deposit = {
+            token,
+            sender,
+            tokenIds: [1n, 2n, 3n],
+            values: [100n, 200n, 300n],
+            baseLayerData: "0xabcd",
+            execLayerData: "0xdeadbeef",
+        } as const;
+        expect(
+            decodeDeposit({
+                msgSender: erc1155BatchPortalAddress,
+                payload: encodeErc1155BatchDeposit(deposit, "bytes"),
+            }),
+        ).toEqual({
+            type: "Erc1155BatchDeposit",
+            ...deposit,
+            baseLayerData: hexToBytes("0xabcd"),
+            execLayerData: hexToBytes("0xdeadbeef"),
+        });
+    });
+
+    it("should return undefined for a byte array payload when msgSender is not a portal", () => {
+        expect(
+            decodeDeposit({
+                msgSender: sender,
+                payload: hexToBytes("0xdeadbeef"),
+            }),
+        ).toBeUndefined();
     });
 });

--- a/packages/codec/__tests__/input.test.ts
+++ b/packages/codec/__tests__/input.test.ts
@@ -1,4 +1,4 @@
-import { getAddress, slice } from "viem";
+import { bytesToHex, getAddress, hexToBytes, slice } from "viem";
 import { describe, expect, it } from "vitest";
 import { decodeInput, encodeInput, type Input } from "../src/input.js";
 
@@ -60,5 +60,70 @@ describe("input", () => {
 
     it("should throw on data with an unknown function selector", () => {
         expect(() => decodeInput("0xdeadbeef")).toThrow();
+    });
+});
+
+describe("input (byte array)", () => {
+    const encodedInputBytes = hexToBytes(encodedInput);
+    const inputBytes: Input<Uint8Array> = {
+        ...input,
+        payload: hexToBytes("0xdeadbeef"),
+    };
+
+    it("should decode an EvmAdvance call from a byte array", () => {
+        expect(decodeInput(encodedInputBytes)).toEqual(inputBytes);
+    });
+
+    it("should return the payload as a zero-copy view of the data", () => {
+        const decoded = decodeInput(encodedInputBytes);
+        expect(decoded.payload.buffer).toBe(encodedInputBytes.buffer);
+        expect(decoded.payload.byteOffset).toBe(4 + 9 * 32);
+        expect(decoded.payload.length).toBe(4);
+    });
+
+    it("should decode from a Buffer", () => {
+        const decoded = decodeInput(Buffer.from(encodedInput.slice(2), "hex"));
+        expect(bytesToHex(decoded.payload)).toEqual("0xdeadbeef");
+        expect(decoded.chainId).toEqual(input.chainId);
+        expect(decoded.appContract).toEqual(input.appContract);
+    });
+
+    it("should encode to a byte array", () => {
+        expect(encodeInput(input, "bytes")).toEqual(encodedInputBytes);
+        expect(encodeInput(inputBytes, "bytes")).toEqual(encodedInputBytes);
+    });
+
+    it("should encode a byte array payload to hex", () => {
+        expect(encodeInput(inputBytes)).toEqual(encodedInput);
+        expect(encodeInput(inputBytes, "hex")).toEqual(encodedInput);
+    });
+
+    it("should roundtrip an input through encode and decode", () => {
+        const original: Input<Uint8Array> = {
+            chainId: 31337n,
+            appContract: getAddress(
+                "0x67742ff5b2b762503ff0a92738c6fc2ea4a4d182",
+            ),
+            msgSender: getAddress("0x92cc14432c1f82622493abd64d99ea8a3000a7c7"),
+            blockNumber: 123456789n,
+            blockTimestamp: 1744255407n,
+            prevRandao: 2n ** 200n,
+            index: 42n,
+            payload: new Uint8Array(),
+        };
+        expect(decodeInput(encodeInput(original, "bytes"))).toEqual(original);
+    });
+
+    it("should throw on a byte array with an unknown function selector", () => {
+        expect(() => decodeInput(hexToBytes("0xdeadbeef"))).toThrow();
+    });
+
+    it("should throw on values out of uint256 range", () => {
+        expect(() => encodeInput({ ...input, chainId: -1n }, "bytes")).toThrow(
+            "out of uint256 range",
+        );
+        expect(() =>
+            encodeInput({ ...input, chainId: 2n ** 256n }, "bytes"),
+        ).toThrow("out of uint256 range");
     });
 });

--- a/packages/codec/__tests__/output.test.ts
+++ b/packages/codec/__tests__/output.test.ts
@@ -1,4 +1,4 @@
-import { getAddress, slice } from "viem";
+import { getAddress, hexToBytes, slice } from "viem";
 import { describe, expect, it } from "vitest";
 import {
     decodeOutput,
@@ -8,6 +8,7 @@ import {
     encodeOutput,
     encodeVoucher,
     type Notice,
+    type Output,
     type Voucher,
 } from "../src/output.js";
 
@@ -100,5 +101,93 @@ describe("output", () => {
 
     it("should throw on data with an unknown function selector", () => {
         expect(() => decodeOutput("0x415bf363")).toThrow();
+    });
+});
+
+describe("output (byte array)", () => {
+    const payloadBytes = hexToBytes("0xdeadbeef");
+    const noticeBytes: Notice<Uint8Array> = {
+        type: "Notice",
+        payload: payloadBytes,
+    };
+    const voucherBytes: Voucher<Uint8Array> = {
+        ...voucher,
+        payload: payloadBytes,
+    };
+    const delegateCallVoucherBytes: DelegateCallVoucher<Uint8Array> = {
+        ...delegateCallVoucher,
+        payload: payloadBytes,
+    };
+
+    it("should decode a notice from a byte array", () => {
+        expect(decodeOutput(hexToBytes(encodedNotice))).toEqual(noticeBytes);
+    });
+
+    it("should decode a voucher from a byte array", () => {
+        expect(decodeOutput(hexToBytes(encodedVoucher))).toEqual(voucherBytes);
+    });
+
+    it("should decode a delegate call voucher from a byte array", () => {
+        expect(decodeOutput(hexToBytes(encodedDelegateCallVoucher))).toEqual(
+            delegateCallVoucherBytes,
+        );
+    });
+
+    it("should return the payload as a zero-copy view of the data", () => {
+        const data = hexToBytes(encodedNotice);
+        const decoded = decodeOutput(data);
+        expect(decoded.payload.buffer).toBe(data.buffer);
+        expect(decoded.payload.byteOffset).toBe(4 + 2 * 32);
+        expect(decoded.payload.length).toBe(4);
+    });
+
+    it("should encode outputs to byte arrays", () => {
+        expect(encodeNotice(noticeBytes, "bytes")).toEqual(
+            hexToBytes(encodedNotice),
+        );
+        expect(encodeVoucher(voucher, "bytes")).toEqual(
+            hexToBytes(encodedVoucher),
+        );
+        expect(encodeDelegateCallVoucher(delegateCallVoucher, "bytes")).toEqual(
+            hexToBytes(encodedDelegateCallVoucher),
+        );
+        expect(encodeOutput(voucherBytes, "bytes")).toEqual(
+            hexToBytes(encodedVoucher),
+        );
+    });
+
+    it("should encode byte array payloads to hex", () => {
+        expect(encodeOutput(noticeBytes)).toEqual(encodedNotice);
+        expect(encodeOutput(voucherBytes)).toEqual(encodedVoucher);
+        expect(encodeOutput(delegateCallVoucherBytes)).toEqual(
+            encodedDelegateCallVoucher,
+        );
+    });
+
+    it("should roundtrip outputs through encode and decode", () => {
+        const destination = getAddress(
+            "0x67742ff5b2b762503ff0a92738c6fc2ea4a4d182",
+        );
+        const outputs: Output<Uint8Array>[] = [
+            { type: "Notice", payload: new Uint8Array() },
+            {
+                type: "Voucher",
+                destination,
+                value: 0n,
+                payload: hexToBytes("0x095ea7b3"),
+            },
+            {
+                type: "DelegateCallVoucher",
+                destination,
+                payload: new Uint8Array(),
+            },
+        ];
+        for (const output of outputs) {
+            expect(decodeOutput(encodeOutput(output, "bytes"))).toEqual(output);
+        }
+    });
+
+    it("should throw on a byte array with an unknown function selector", () => {
+        expect(() => decodeOutput(hexToBytes("0x415bf363"))).toThrow();
     });
 });

--- a/packages/codec/__tests__/portal.test.ts
+++ b/packages/codec/__tests__/portal.test.ts
@@ -3,6 +3,7 @@ import {
     encodeAbiParameters,
     getAddress,
     type Hex,
+    hexToBytes,
     numberToHex,
 } from "viem";
 import { describe, expect, it } from "vitest";
@@ -262,5 +263,193 @@ describe("erc1155 batch deposit", () => {
         expect(() => decodeErc1155BatchDeposit("0xdeadbeef")).toThrow(
             "invalid ERC-1155 batch deposit payload",
         );
+    });
+});
+
+describe("deposits (byte array)", () => {
+    const execLayerData = hexToBytes("0xdeadbeef");
+    const baseLayerData = hexToBytes("0xabcd");
+
+    it("should decode and encode an Ether deposit", () => {
+        const deposit: EtherDeposit<Uint8Array> = {
+            sender,
+            value: 123456789n,
+            execLayerData,
+        };
+        const payload = concat([
+            sender,
+            numberToHex(123456789n, { size: 32 }),
+            "0xdeadbeef",
+        ]);
+        expect(decodeEtherDeposit(hexToBytes(payload))).toEqual(deposit);
+        expect(encodeEtherDeposit(deposit, "bytes")).toEqual(
+            hexToBytes(payload),
+        );
+        expect(encodeEtherDeposit(deposit)).toEqual(payload.toLowerCase());
+    });
+
+    it("should decode and encode an ERC-20 deposit", () => {
+        const deposit: Erc20Deposit<Uint8Array> = {
+            token,
+            sender,
+            value: 1000000000000000000n,
+            execLayerData,
+        };
+        const payload = concat([
+            token,
+            sender,
+            numberToHex(1000000000000000000n, { size: 32 }),
+            "0xdeadbeef",
+        ]);
+        expect(decodeErc20Deposit(hexToBytes(payload))).toEqual(deposit);
+        expect(encodeErc20Deposit(deposit, "bytes")).toEqual(
+            hexToBytes(payload),
+        );
+    });
+
+    it("should return execLayerData as a zero-copy view of the payload", () => {
+        const payload = hexToBytes(
+            concat([
+                token,
+                sender,
+                numberToHex(1n, { size: 32 }),
+                "0xdeadbeef",
+            ]),
+        );
+        const decoded = decodeErc20Deposit(payload);
+        expect(decoded.execLayerData.buffer).toBe(payload.buffer);
+        expect(decoded.execLayerData.byteOffset).toBe(72);
+        expect(decoded.execLayerData.length).toBe(4);
+    });
+
+    it("should decode and encode an ERC-721 deposit", () => {
+        const deposit: Erc721Deposit<Uint8Array> = {
+            token,
+            sender,
+            tokenId: 42n,
+            baseLayerData,
+            execLayerData,
+        };
+        const payload = concat([
+            token,
+            sender,
+            numberToHex(42n, { size: 32 }),
+            dataTail("0xabcd", "0xdeadbeef"),
+        ]);
+        expect(decodeErc721Deposit(hexToBytes(payload))).toEqual(deposit);
+        expect(encodeErc721Deposit(deposit, "bytes")).toEqual(
+            hexToBytes(payload),
+        );
+        expect(encodeErc721Deposit(deposit)).toEqual(payload.toLowerCase());
+    });
+
+    it("should decode and encode an ERC-1155 single deposit", () => {
+        const deposit: Erc1155SingleDeposit<Uint8Array> = {
+            token,
+            sender,
+            tokenId: 42n,
+            value: 7n,
+            baseLayerData,
+            execLayerData,
+        };
+        const payload = concat([
+            token,
+            sender,
+            numberToHex(42n, { size: 32 }),
+            numberToHex(7n, { size: 32 }),
+            dataTail("0xabcd", "0xdeadbeef"),
+        ]);
+        expect(decodeErc1155SingleDeposit(hexToBytes(payload))).toEqual(
+            deposit,
+        );
+        expect(encodeErc1155SingleDeposit(deposit, "bytes")).toEqual(
+            hexToBytes(payload),
+        );
+    });
+
+    it("should decode and encode an ERC-1155 batch deposit", () => {
+        const deposit: Erc1155BatchDeposit<Uint8Array> = {
+            token,
+            sender,
+            tokenIds: [1n, 2n, 3n],
+            values: [100n, 200n, 300n],
+            baseLayerData,
+            execLayerData,
+        };
+        const payload = concat([
+            token,
+            sender,
+            encodeAbiParameters(
+                [
+                    { type: "uint256[]" },
+                    { type: "uint256[]" },
+                    { type: "bytes" },
+                    { type: "bytes" },
+                ],
+                [[1n, 2n, 3n], [100n, 200n, 300n], "0xabcd", "0xdeadbeef"],
+            ),
+        ]);
+        expect(decodeErc1155BatchDeposit(hexToBytes(payload))).toEqual(deposit);
+        expect(encodeErc1155BatchDeposit(deposit, "bytes")).toEqual(
+            hexToBytes(payload),
+        );
+        expect(encodeErc1155BatchDeposit(deposit)).toEqual(
+            payload.toLowerCase(),
+        );
+    });
+
+    it("should roundtrip deposits with empty data", () => {
+        const erc721: Erc721Deposit<Uint8Array> = {
+            token,
+            sender,
+            tokenId: 0n,
+            baseLayerData: new Uint8Array(),
+            execLayerData: new Uint8Array(),
+        };
+        expect(
+            decodeErc721Deposit(encodeErc721Deposit(erc721, "bytes")),
+        ).toEqual(erc721);
+        const batch: Erc1155BatchDeposit<Uint8Array> = {
+            token,
+            sender,
+            tokenIds: [],
+            values: [],
+            baseLayerData: new Uint8Array(),
+            execLayerData: new Uint8Array(),
+        };
+        expect(
+            decodeErc1155BatchDeposit(
+                encodeErc1155BatchDeposit(batch, "bytes"),
+            ),
+        ).toEqual(batch);
+    });
+
+    it("should throw on a payload that is too short", () => {
+        const short = hexToBytes("0xdeadbeef");
+        expect(() => decodeEtherDeposit(short)).toThrow(
+            "invalid Ether deposit payload",
+        );
+        expect(() => decodeErc20Deposit(short)).toThrow(
+            "invalid ERC-20 deposit payload",
+        );
+        expect(() => decodeErc721Deposit(short)).toThrow(
+            "invalid ERC-721 deposit payload",
+        );
+        expect(() => decodeErc1155SingleDeposit(short)).toThrow(
+            "invalid ERC-1155 single deposit payload",
+        );
+        expect(() => decodeErc1155BatchDeposit(short)).toThrow(
+            "invalid ERC-1155 batch deposit payload",
+        );
+    });
+
+    it("should throw on a payload with a malformed data tail", () => {
+        expect(() =>
+            decodeErc721Deposit(
+                hexToBytes(
+                    concat([token, sender, numberToHex(42n, { size: 32 })]),
+                ),
+            ),
+        ).toThrow("data out of bounds");
     });
 });

--- a/packages/codec/src/bytes.ts
+++ b/packages/codec/src/bytes.ts
@@ -90,9 +90,10 @@ export const readAbiUint256Array = (
 ): bigint[] => {
     const offset = base + readSize(data, pointer);
     const length = readSize(data, offset);
-    const values: bigint[] = [];
+    assertReadable(data, offset + WORD * (1 + length));
+    const values = new Array<bigint>(length);
     for (let i = 0; i < length; i++) {
-        values.push(readUint256(data, offset + WORD * (i + 1)));
+        values[i] = readUint256(data, offset + WORD * (i + 1));
     }
     return values;
 };

--- a/packages/codec/src/bytes.ts
+++ b/packages/codec/src/bytes.ts
@@ -1,0 +1,187 @@
+import {
+    type Address,
+    type ByteArray,
+    bytesToBigInt,
+    bytesToHex,
+    getAddress,
+    type Hex,
+    hexToBytes,
+} from "viem";
+
+// hand-rolled byte-level readers and writers used by the byte array codec
+// paths; readers return zero-copy subarrays for variable-size fields, writers
+// fill a preallocated buffer and return the offset just past what they wrote
+
+/** Size of an ABI word in bytes. */
+export const WORD = 32;
+
+/** Round `length` up to whole ABI words. */
+export const ceilWord = (length: number): number =>
+    Math.ceil(length / WORD) * WORD;
+
+/** Normalize a byte field to a byte array. */
+export const asBytes = (value: Hex | ByteArray): ByteArray =>
+    typeof value === "string" ? hexToBytes(value) : value;
+
+/** Normalize a byte field to a hex string. */
+export const asHex = (value: Hex | ByteArray): Hex =>
+    typeof value === "string" ? value : bytesToHex(value);
+
+/** Whether `data` starts with the 4-byte function `selector`. */
+export const hasSelector = (data: ByteArray, selector: ByteArray): boolean =>
+    selector.every((byte, i) => data[i] === byte);
+
+const assertReadable = (data: ByteArray, end: number): void => {
+    if (end > data.length) {
+        throw new Error(
+            `data out of bounds: expected at least ${end} bytes, got ${data.length}`,
+        );
+    }
+};
+
+/** Read the 20-byte address at `offset`, returned checksummed. */
+export const readAddress = (data: ByteArray, offset: number): Address => {
+    assertReadable(data, offset + 20);
+    return getAddress(bytesToHex(data.subarray(offset, offset + 20)));
+};
+
+/** Read the address right-aligned in the ABI word at `offset`. */
+export const readAddressWord = (data: ByteArray, offset: number): Address =>
+    readAddress(data, offset + WORD - 20);
+
+/** Read the big-endian uint256 at `offset`. */
+export const readUint256 = (data: ByteArray, offset: number): bigint => {
+    assertReadable(data, offset + WORD);
+    return bytesToBigInt(data.subarray(offset, offset + WORD));
+};
+
+// uint256 offset or length that must fit in a JS number
+const readSize = (data: ByteArray, offset: number): number => {
+    const value = readUint256(data, offset);
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error(`data offset or size out of bounds: ${value}`);
+    }
+    return Number(value);
+};
+
+/**
+ * Read the dynamic ABI `bytes` whose offset pointer sits at `pointer`, with
+ * offsets relative to `base`. Returns a zero-copy subarray of `data`.
+ */
+export const readAbiBytes = (
+    data: ByteArray,
+    base: number,
+    pointer: number,
+): ByteArray => {
+    const offset = base + readSize(data, pointer);
+    const length = readSize(data, offset);
+    assertReadable(data, offset + WORD + length);
+    return data.subarray(offset + WORD, offset + WORD + length);
+};
+
+/**
+ * Read the dynamic ABI `uint256[]` whose offset pointer sits at `pointer`,
+ * with offsets relative to `base`.
+ */
+export const readAbiUint256Array = (
+    data: ByteArray,
+    base: number,
+    pointer: number,
+): bigint[] => {
+    const offset = base + readSize(data, pointer);
+    const length = readSize(data, offset);
+    const values: bigint[] = [];
+    for (let i = 0; i < length; i++) {
+        values.push(readUint256(data, offset + WORD * (i + 1)));
+    }
+    return values;
+};
+
+/** Write `value` at `offset`. */
+export const writeBytes = (
+    data: Uint8Array,
+    offset: number,
+    value: ByteArray,
+): number => {
+    data.set(value, offset);
+    return offset + value.length;
+};
+
+/** Write `value` at `offset`, zero-padded on the right to whole ABI words. */
+export const writePaddedBytes = (
+    data: Uint8Array,
+    offset: number,
+    value: ByteArray,
+): number => {
+    data.set(value, offset);
+    return offset + ceilWord(value.length);
+};
+
+/** Write the 20-byte `address` at `offset`. */
+export const writeAddress = (
+    data: Uint8Array,
+    offset: number,
+    address: Address,
+): number => writeBytes(data, offset, hexToBytes(address));
+
+/** Write `address` right-aligned in the ABI word at `offset`. */
+export const writeAddressWord = (
+    data: Uint8Array,
+    offset: number,
+    address: Address,
+): number => {
+    writeAddress(data, offset + WORD - 20, address);
+    return offset + WORD;
+};
+
+const MAX_UINT256 = 2n ** 256n - 1n;
+
+/** Write `value` as a big-endian uint256 at `offset`. */
+export const writeUint256 = (
+    data: Uint8Array,
+    offset: number,
+    value: bigint,
+): number => {
+    if (value < 0n || value > MAX_UINT256) {
+        throw new Error(`number out of uint256 range: ${value}`);
+    }
+    let rest = value;
+    for (let i = WORD - 1; i >= 0; i--) {
+        data[offset + i] = Number(rest & 0xffn);
+        rest >>= 8n;
+    }
+    return offset + WORD;
+};
+
+/** Write the length word of `value` followed by its right-padded contents. */
+export const writeAbiBytes = (
+    data: Uint8Array,
+    offset: number,
+    value: ByteArray,
+): number =>
+    writePaddedBytes(
+        data,
+        writeUint256(data, offset, BigInt(value.length)),
+        value,
+    );
+
+/** Write the length word of `values` followed by one word per element. */
+export const writeAbiUint256Array = (
+    data: Uint8Array,
+    offset: number,
+    values: readonly bigint[],
+): number => {
+    let next = writeUint256(data, offset, BigInt(values.length));
+    for (const value of values) {
+        next = writeUint256(data, next, value);
+    }
+    return next;
+};
+
+/** Encoded size of a dynamic ABI `bytes` tail item. */
+export const abiBytesSize = (value: ByteArray): number =>
+    WORD + ceilWord(value.length);
+
+/** Encoded size of a dynamic ABI `uint256[]` tail item. */
+export const abiUint256ArraySize = (values: readonly bigint[]): number =>
+    WORD * (1 + values.length);

--- a/packages/codec/src/index.ts
+++ b/packages/codec/src/index.ts
@@ -29,6 +29,7 @@ export {
     type Output,
     type Voucher,
 } from "./output.js";
+export type { DecodedBytes, EncodedData, To } from "./types.js";
 export {
     erc1155BatchPortalAddress,
     erc1155SinglePortalAddress,

--- a/packages/codec/src/index.ts
+++ b/packages/codec/src/index.ts
@@ -29,7 +29,7 @@ export {
     type Output,
     type Voucher,
 } from "./output.js";
-export type { DecodedBytes, EncodedData, To } from "./types.js";
+export type { To } from "./types.js";
 export {
     erc1155BatchPortalAddress,
     erc1155SinglePortalAddress,

--- a/packages/codec/src/input.ts
+++ b/packages/codec/src/input.ts
@@ -1,28 +1,51 @@
 import type { ExtractAbiFunction } from "abitype";
-import { decodeFunctionData, encodeFunctionData, type Hex } from "viem";
+import {
+    AbiFunctionSignatureNotFoundError,
+    type ByteArray,
+    bytesToHex,
+    decodeFunctionData,
+    encodeFunctionData,
+    getAbiItem,
+    type Hex,
+    hexToBytes,
+    toFunctionSelector,
+} from "viem";
+import {
+    asBytes,
+    asHex,
+    ceilWord,
+    hasSelector,
+    readAbiBytes,
+    readAddressWord,
+    readUint256,
+    WORD,
+    writeAbiBytes,
+    writeAddressWord,
+    writeBytes,
+    writeUint256,
+} from "./bytes.js";
 import { inputsAbi } from "./rollups.js";
-import type { ParamsToObject } from "./types.js";
+import type { DecodedBytes, EncodedData, ParamsToObject, To } from "./types.js";
 
 /**
  * Input of a Cartesi application. Inputs are encoded as `EvmAdvance` calls
  * by the `InputBox` contract when added on the base layer; the node just
  * forwards the encoded blob to the machine. Field names and types are
  * inferred from the arguments of the `EvmAdvance` function of the rollups
- * contracts `Inputs` interface.
+ * contracts `Inputs` interface. The `bytes` parameter selects the
+ * representation of the `payload` field: `Hex` (the default) or `Uint8Array`.
  */
-export type Input = ParamsToObject<
-    ExtractAbiFunction<typeof inputsAbi, "EvmAdvance">["inputs"]
+export type Input<bytes extends Hex | ByteArray = Hex> = ParamsToObject<
+    ExtractAbiFunction<typeof inputsAbi, "EvmAdvance">["inputs"],
+    bytes
 >;
 
-/**
- * Decode a blob of input data as an `EvmAdvance` call of the rollups
- * contracts `Inputs` interface.
- * @param data ABI-encoded input data
- * @returns decoded input
- * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
- * with the `EvmAdvance` function selector
- */
-export const decodeInput = (data: Hex): Input => {
+const selector = toFunctionSelector(
+    getAbiItem({ abi: inputsAbi, name: "EvmAdvance" }),
+);
+const selectorBytes = hexToBytes(selector);
+
+const decodeInputHex = (data: Hex): Input => {
     const {
         args: [
             chainId,
@@ -47,24 +70,89 @@ export const decodeInput = (data: Hex): Input => {
     };
 };
 
+// hand-rolled decoder over the fixed EvmAdvance calldata layout, so byte
+// array data is decoded without a hex conversion and the payload is a
+// zero-copy subarray of the data
+const decodeInputBytes = (data: ByteArray): Input<ByteArray> => {
+    if (!hasSelector(data, selectorBytes)) {
+        throw new AbiFunctionSignatureNotFoundError(
+            bytesToHex(data.subarray(0, 4)),
+            { docsPath: "/docs/contract/decodeFunctionData" },
+        );
+    }
+    const base = 4;
+    return {
+        chainId: readUint256(data, base),
+        appContract: readAddressWord(data, base + WORD),
+        msgSender: readAddressWord(data, base + 2 * WORD),
+        blockNumber: readUint256(data, base + 3 * WORD),
+        blockTimestamp: readUint256(data, base + 4 * WORD),
+        prevRandao: readUint256(data, base + 5 * WORD),
+        index: readUint256(data, base + 6 * WORD),
+        payload: readAbiBytes(data, base, base + 7 * WORD),
+    };
+};
+
+/**
+ * Decode a blob of input data as an `EvmAdvance` call of the rollups
+ * contracts `Inputs` interface.
+ * @param data ABI-encoded input data, as a hex string or byte array
+ * @returns decoded input; the `payload` follows the representation of `data`,
+ * and is a zero-copy subarray when `data` is a byte array
+ * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
+ * with the `EvmAdvance` function selector
+ */
+export const decodeInput = <data extends Hex | ByteArray>(
+    data: data,
+): Input<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = data;
+    return (
+        typeof blob === "string" ? decodeInputHex(blob) : decodeInputBytes(blob)
+    ) as Input<DecodedBytes<data>>;
+};
+
+const encodeInputBytes = (input: Input<Hex | ByteArray>): ByteArray => {
+    const payload = asBytes(input.payload);
+    const data = new Uint8Array(4 + 9 * WORD + ceilWord(payload.length));
+    let offset = writeBytes(data, 0, selectorBytes);
+    offset = writeUint256(data, offset, input.chainId);
+    offset = writeAddressWord(data, offset, input.appContract);
+    offset = writeAddressWord(data, offset, input.msgSender);
+    offset = writeUint256(data, offset, input.blockNumber);
+    offset = writeUint256(data, offset, input.blockTimestamp);
+    offset = writeUint256(data, offset, input.prevRandao);
+    offset = writeUint256(data, offset, input.index);
+    offset = writeUint256(data, offset, BigInt(8 * WORD)); // payload offset
+    writeAbiBytes(data, offset, payload);
+    return data;
+};
+
 /**
  * Encode an input as an `EvmAdvance` call of the rollups contracts `Inputs`
  * interface. This is the inverse of `decodeInput`, useful for testing.
- * @param input input to encode
+ * @param input input to encode; the `payload` may be a hex string or byte
+ * array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns ABI-encoded input data
  */
-export const encodeInput = (input: Input): Hex =>
-    encodeFunctionData({
-        abi: inputsAbi,
-        functionName: "EvmAdvance",
-        args: [
-            input.chainId,
-            input.appContract,
-            input.msgSender,
-            input.blockNumber,
-            input.blockTimestamp,
-            input.prevRandao,
-            input.index,
-            input.payload,
-        ],
-    });
+export const encodeInput = <to extends To = "hex">(
+    input: Input<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> =>
+    (to === "bytes"
+        ? encodeInputBytes(input)
+        : encodeFunctionData({
+              abi: inputsAbi,
+              functionName: "EvmAdvance",
+              args: [
+                  input.chainId,
+                  input.appContract,
+                  input.msgSender,
+                  input.blockNumber,
+                  input.blockTimestamp,
+                  input.prevRandao,
+                  input.index,
+                  asHex(input.payload),
+              ],
+          })) as EncodedData<to>;

--- a/packages/codec/src/input.ts
+++ b/packages/codec/src/input.ts
@@ -25,7 +25,7 @@ import {
     writeUint256,
 } from "./bytes.js";
 import { inputsAbi } from "./rollups.js";
-import type { DecodedBytes, EncodedData, ParamsToObject, To } from "./types.js";
+import type { ParamsToObject, To } from "./types.js";
 
 /**
  * Input of a Cartesi application. Inputs are encoded as `EvmAdvance` calls
@@ -102,14 +102,14 @@ const decodeInputBytes = (data: ByteArray): Input<ByteArray> => {
  * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
  * with the `EvmAdvance` function selector
  */
-export const decodeInput = <data extends Hex | ByteArray>(
-    data: data,
-): Input<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = data;
-    return (
-        typeof blob === "string" ? decodeInputHex(blob) : decodeInputBytes(blob)
-    ) as Input<DecodedBytes<data>>;
-};
+export function decodeInput(data: Hex): Input;
+export function decodeInput(data: ByteArray): Input<ByteArray>;
+export function decodeInput(data: Hex | ByteArray): Input<Hex | ByteArray>;
+export function decodeInput(data: Hex | ByteArray): Input<Hex | ByteArray> {
+    return typeof data === "string"
+        ? decodeInputHex(data)
+        : decodeInputBytes(data);
+}
 
 const encodeInputBytes = (input: Input<Hex | ByteArray>): ByteArray => {
     const payload = asBytes(input.payload);
@@ -136,11 +136,20 @@ const encodeInputBytes = (input: Input<Hex | ByteArray>): ByteArray => {
  * `"bytes"`
  * @returns ABI-encoded input data
  */
-export const encodeInput = <to extends To = "hex">(
+export function encodeInput(input: Input<Hex | ByteArray>, to?: "hex"): Hex;
+export function encodeInput(
     input: Input<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> =>
-    (to === "bytes"
+    to: "bytes",
+): ByteArray;
+export function encodeInput(
+    input: Input<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeInput(
+    input: Input<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
+    return to === "bytes"
         ? encodeInputBytes(input)
         : encodeFunctionData({
               abi: inputsAbi,
@@ -155,4 +164,5 @@ export const encodeInput = <to extends To = "hex">(
                   input.index,
                   asHex(input.payload),
               ],
-          })) as EncodedData<to>;
+          });
+}

--- a/packages/codec/src/output.ts
+++ b/packages/codec/src/output.ts
@@ -1,18 +1,53 @@
 import type { ExtractAbiFunction, ExtractAbiFunctionNames } from "abitype";
-import { decodeFunctionData, encodeFunctionData, type Hex } from "viem";
+import {
+    AbiFunctionSignatureNotFoundError,
+    type ByteArray,
+    bytesToHex,
+    decodeFunctionData,
+    encodeFunctionData,
+    getAbiItem,
+    type Hex,
+    hexToBytes,
+    toFunctionSelector,
+} from "viem";
+import {
+    asBytes,
+    asHex,
+    ceilWord,
+    hasSelector,
+    readAbiBytes,
+    readAddressWord,
+    readUint256,
+    WORD,
+    writeAbiBytes,
+    writeAddressWord,
+    writeBytes,
+    writeUint256,
+} from "./bytes.js";
 import { outputsAbi } from "./rollups.js";
-import type { ParamsToObject, Prettify } from "./types.js";
+import type {
+    DecodedBytes,
+    EncodedData,
+    ParamsToObject,
+    Prettify,
+    To,
+} from "./types.js";
 
 type OutputName = ExtractAbiFunctionNames<typeof outputsAbi>;
 
 /**
  * Output variant named `name`, with the `type` discriminator field plus
  * fields inferred from the arguments of the homonymous function of the
- * rollups contracts `Outputs` interface.
+ * rollups contracts `Outputs` interface. The `bytes` parameter selects the
+ * representation of the `payload` field: `Hex` (the default) or `Uint8Array`.
  */
-type OutputOf<name extends OutputName> = Prettify<
+type OutputOf<
+    name extends OutputName,
+    bytes extends Hex | ByteArray = Hex,
+> = Prettify<
     { type: name } & ParamsToObject<
-        ExtractAbiFunction<typeof outputsAbi, name>["inputs"]
+        ExtractAbiFunction<typeof outputsAbi, name>["inputs"],
+        bytes
     >
 >;
 
@@ -20,36 +55,46 @@ type OutputOf<name extends OutputName> = Prettify<
  * Notice output: informational statement that can be validated on the base
  * layer, but not executed.
  */
-export type Notice = OutputOf<"Notice">;
+export type Notice<bytes extends Hex | ByteArray = Hex> = OutputOf<
+    "Notice",
+    bytes
+>;
 
 /**
  * Voucher output: a single-use permission to execute a `CALL` to a base layer
  * contract on behalf of the application.
  */
-export type Voucher = OutputOf<"Voucher">;
+export type Voucher<bytes extends Hex | ByteArray = Hex> = OutputOf<
+    "Voucher",
+    bytes
+>;
 
 /**
  * Delegate call voucher output: a single-use permission to execute a
  * `DELEGATECALL` to a base layer contract in the context of the application
  * contract.
  */
-export type DelegateCallVoucher = OutputOf<"DelegateCallVoucher">;
+export type DelegateCallVoucher<bytes extends Hex | ByteArray = Hex> = OutputOf<
+    "DelegateCallVoucher",
+    bytes
+>;
 
 /**
  * Output of a Cartesi application, as defined by the rollups contracts
  * `Outputs` interface, discriminated by the `type` field.
  */
-export type Output = { [name in OutputName]: OutputOf<name> }[OutputName];
+export type Output<bytes extends Hex | ByteArray = Hex> = {
+    [name in OutputName]: OutputOf<name, bytes>;
+}[OutputName];
 
-/**
- * Decode a blob of output data as one of the functions of the rollups
- * contracts `Outputs` interface.
- * @param data ABI-encoded output data
- * @returns decoded output, discriminated by the `type` field
- * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
- * with the selector of one of the `Outputs` functions
- */
-export const decodeOutput = (data: Hex): Output => {
+const selectorOf = (name: OutputName): ByteArray =>
+    hexToBytes(toFunctionSelector(getAbiItem({ abi: outputsAbi, name })));
+
+const noticeSelector = selectorOf("Notice");
+const voucherSelector = selectorOf("Voucher");
+const delegateCallVoucherSelector = selectorOf("DelegateCallVoucher");
+
+const decodeOutputHex = (data: Hex): Output => {
     const decoded = decodeFunctionData({ abi: outputsAbi, data });
     switch (decoded.functionName) {
         case "Notice": {
@@ -67,60 +112,181 @@ export const decodeOutput = (data: Hex): Output => {
     }
 };
 
+// hand-rolled decoder over the fixed Outputs calldata layouts, so byte array
+// data is decoded without a hex conversion and the payload is a zero-copy
+// subarray of the data
+const decodeOutputBytes = (data: ByteArray): Output<ByteArray> => {
+    const base = 4;
+    if (hasSelector(data, noticeSelector)) {
+        return {
+            type: "Notice",
+            payload: readAbiBytes(data, base, base),
+        };
+    }
+    if (hasSelector(data, voucherSelector)) {
+        return {
+            type: "Voucher",
+            destination: readAddressWord(data, base),
+            value: readUint256(data, base + WORD),
+            payload: readAbiBytes(data, base, base + 2 * WORD),
+        };
+    }
+    if (hasSelector(data, delegateCallVoucherSelector)) {
+        return {
+            type: "DelegateCallVoucher",
+            destination: readAddressWord(data, base),
+            payload: readAbiBytes(data, base, base + WORD),
+        };
+    }
+    throw new AbiFunctionSignatureNotFoundError(
+        bytesToHex(data.subarray(0, 4)),
+        { docsPath: "/docs/contract/decodeFunctionData" },
+    );
+};
+
+/**
+ * Decode a blob of output data as one of the functions of the rollups
+ * contracts `Outputs` interface.
+ * @param data ABI-encoded output data, as a hex string or byte array
+ * @returns decoded output, discriminated by the `type` field; the `payload`
+ * follows the representation of `data`, and is a zero-copy subarray when
+ * `data` is a byte array
+ * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
+ * with the selector of one of the `Outputs` functions
+ */
+export const decodeOutput = <data extends Hex | ByteArray>(
+    data: data,
+): Output<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = data;
+    return (
+        typeof blob === "string"
+            ? decodeOutputHex(blob)
+            : decodeOutputBytes(blob)
+    ) as Output<DecodedBytes<data>>;
+};
+
+const encodeNoticeBytes = (
+    notice: Omit<Notice<Hex | ByteArray>, "type">,
+): ByteArray => {
+    const payload = asBytes(notice.payload);
+    const data = new Uint8Array(4 + 2 * WORD + ceilWord(payload.length));
+    let offset = writeBytes(data, 0, noticeSelector);
+    offset = writeUint256(data, offset, BigInt(WORD)); // payload offset
+    writeAbiBytes(data, offset, payload);
+    return data;
+};
+
 /**
  * Encode a notice as a `Notice` call of the rollups contracts `Outputs`
  * interface.
- * @param notice notice to encode
+ * @param notice notice to encode; the `payload` may be a hex string or byte
+ * array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeNotice = (notice: Omit<Notice, "type">): Hex =>
-    encodeFunctionData({
-        abi: outputsAbi,
-        functionName: "Notice",
-        args: [notice.payload],
-    });
+export const encodeNotice = <to extends To = "hex">(
+    notice: Omit<Notice<Hex | ByteArray>, "type">,
+    to?: to,
+): EncodedData<to> =>
+    (to === "bytes"
+        ? encodeNoticeBytes(notice)
+        : encodeFunctionData({
+              abi: outputsAbi,
+              functionName: "Notice",
+              args: [asHex(notice.payload)],
+          })) as EncodedData<to>;
+
+const encodeVoucherBytes = (
+    voucher: Omit<Voucher<Hex | ByteArray>, "type">,
+): ByteArray => {
+    const payload = asBytes(voucher.payload);
+    const data = new Uint8Array(4 + 4 * WORD + ceilWord(payload.length));
+    let offset = writeBytes(data, 0, voucherSelector);
+    offset = writeAddressWord(data, offset, voucher.destination);
+    offset = writeUint256(data, offset, voucher.value);
+    offset = writeUint256(data, offset, BigInt(3 * WORD)); // payload offset
+    writeAbiBytes(data, offset, payload);
+    return data;
+};
 
 /**
  * Encode a voucher as a `Voucher` call of the rollups contracts `Outputs`
  * interface.
- * @param voucher voucher to encode
+ * @param voucher voucher to encode; the `payload` may be a hex string or byte
+ * array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeVoucher = (voucher: Omit<Voucher, "type">): Hex =>
-    encodeFunctionData({
-        abi: outputsAbi,
-        functionName: "Voucher",
-        args: [voucher.destination, voucher.value, voucher.payload],
-    });
+export const encodeVoucher = <to extends To = "hex">(
+    voucher: Omit<Voucher<Hex | ByteArray>, "type">,
+    to?: to,
+): EncodedData<to> =>
+    (to === "bytes"
+        ? encodeVoucherBytes(voucher)
+        : encodeFunctionData({
+              abi: outputsAbi,
+              functionName: "Voucher",
+              args: [
+                  voucher.destination,
+                  voucher.value,
+                  asHex(voucher.payload),
+              ],
+          })) as EncodedData<to>;
+
+const encodeDelegateCallVoucherBytes = (
+    voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
+): ByteArray => {
+    const payload = asBytes(voucher.payload);
+    const data = new Uint8Array(4 + 3 * WORD + ceilWord(payload.length));
+    let offset = writeBytes(data, 0, delegateCallVoucherSelector);
+    offset = writeAddressWord(data, offset, voucher.destination);
+    offset = writeUint256(data, offset, BigInt(2 * WORD)); // payload offset
+    writeAbiBytes(data, offset, payload);
+    return data;
+};
 
 /**
  * Encode a delegate call voucher as a `DelegateCallVoucher` call of the
  * rollups contracts `Outputs` interface.
- * @param voucher delegate call voucher to encode
+ * @param voucher delegate call voucher to encode; the `payload` may be a hex
+ * string or byte array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeDelegateCallVoucher = (
-    voucher: Omit<DelegateCallVoucher, "type">,
-): Hex =>
-    encodeFunctionData({
-        abi: outputsAbi,
-        functionName: "DelegateCallVoucher",
-        args: [voucher.destination, voucher.payload],
-    });
+export const encodeDelegateCallVoucher = <to extends To = "hex">(
+    voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
+    to?: to,
+): EncodedData<to> =>
+    (to === "bytes"
+        ? encodeDelegateCallVoucherBytes(voucher)
+        : encodeFunctionData({
+              abi: outputsAbi,
+              functionName: "DelegateCallVoucher",
+              args: [voucher.destination, asHex(voucher.payload)],
+          })) as EncodedData<to>;
 
 /**
  * Encode an output as one of the functions of the rollups contracts `Outputs`
  * interface. This is the inverse of `decodeOutput`, useful for testing.
- * @param output output to encode, discriminated by the `type` field
+ * @param output output to encode, discriminated by the `type` field; the
+ * `payload` may be a hex string or byte array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeOutput = (output: Output): Hex => {
+export const encodeOutput = <to extends To = "hex">(
+    output: Output<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
     switch (output.type) {
         case "Notice":
-            return encodeNotice(output);
+            return encodeNotice(output, to);
         case "Voucher":
-            return encodeVoucher(output);
+            return encodeVoucher(output, to);
         case "DelegateCallVoucher":
-            return encodeDelegateCallVoucher(output);
+            return encodeDelegateCallVoucher(output, to);
     }
 };

--- a/packages/codec/src/output.ts
+++ b/packages/codec/src/output.ts
@@ -25,13 +25,7 @@ import {
     writeUint256,
 } from "./bytes.js";
 import { outputsAbi } from "./rollups.js";
-import type {
-    DecodedBytes,
-    EncodedData,
-    ParamsToObject,
-    Prettify,
-    To,
-} from "./types.js";
+import type { ParamsToObject, Prettify, To } from "./types.js";
 
 type OutputName = ExtractAbiFunctionNames<typeof outputsAbi>;
 
@@ -154,16 +148,14 @@ const decodeOutputBytes = (data: ByteArray): Output<ByteArray> => {
  * @throws viem `AbiFunctionSignatureNotFoundError` if the data does not start
  * with the selector of one of the `Outputs` functions
  */
-export const decodeOutput = <data extends Hex | ByteArray>(
-    data: data,
-): Output<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = data;
-    return (
-        typeof blob === "string"
-            ? decodeOutputHex(blob)
-            : decodeOutputBytes(blob)
-    ) as Output<DecodedBytes<data>>;
-};
+export function decodeOutput(data: Hex): Output;
+export function decodeOutput(data: ByteArray): Output<ByteArray>;
+export function decodeOutput(data: Hex | ByteArray): Output<Hex | ByteArray>;
+export function decodeOutput(data: Hex | ByteArray): Output<Hex | ByteArray> {
+    return typeof data === "string"
+        ? decodeOutputHex(data)
+        : decodeOutputBytes(data);
+}
 
 const encodeNoticeBytes = (
     notice: Omit<Notice<Hex | ByteArray>, "type">,
@@ -185,17 +177,30 @@ const encodeNoticeBytes = (
  * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeNotice = <to extends To = "hex">(
+export function encodeNotice(
     notice: Omit<Notice<Hex | ByteArray>, "type">,
-    to?: to,
-): EncodedData<to> =>
-    (to === "bytes"
+    to?: "hex",
+): Hex;
+export function encodeNotice(
+    notice: Omit<Notice<Hex | ByteArray>, "type">,
+    to: "bytes",
+): ByteArray;
+export function encodeNotice(
+    notice: Omit<Notice<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray;
+export function encodeNotice(
+    notice: Omit<Notice<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray {
+    return to === "bytes"
         ? encodeNoticeBytes(notice)
         : encodeFunctionData({
               abi: outputsAbi,
               functionName: "Notice",
               args: [asHex(notice.payload)],
-          })) as EncodedData<to>;
+          });
+}
 
 const encodeVoucherBytes = (
     voucher: Omit<Voucher<Hex | ByteArray>, "type">,
@@ -219,11 +224,23 @@ const encodeVoucherBytes = (
  * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeVoucher = <to extends To = "hex">(
+export function encodeVoucher(
     voucher: Omit<Voucher<Hex | ByteArray>, "type">,
-    to?: to,
-): EncodedData<to> =>
-    (to === "bytes"
+    to?: "hex",
+): Hex;
+export function encodeVoucher(
+    voucher: Omit<Voucher<Hex | ByteArray>, "type">,
+    to: "bytes",
+): ByteArray;
+export function encodeVoucher(
+    voucher: Omit<Voucher<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray;
+export function encodeVoucher(
+    voucher: Omit<Voucher<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray {
+    return to === "bytes"
         ? encodeVoucherBytes(voucher)
         : encodeFunctionData({
               abi: outputsAbi,
@@ -233,7 +250,8 @@ export const encodeVoucher = <to extends To = "hex">(
                   voucher.value,
                   asHex(voucher.payload),
               ],
-          })) as EncodedData<to>;
+          });
+}
 
 const encodeDelegateCallVoucherBytes = (
     voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
@@ -256,17 +274,30 @@ const encodeDelegateCallVoucherBytes = (
  * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeDelegateCallVoucher = <to extends To = "hex">(
+export function encodeDelegateCallVoucher(
     voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
-    to?: to,
-): EncodedData<to> =>
-    (to === "bytes"
+    to?: "hex",
+): Hex;
+export function encodeDelegateCallVoucher(
+    voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
+    to: "bytes",
+): ByteArray;
+export function encodeDelegateCallVoucher(
+    voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray;
+export function encodeDelegateCallVoucher(
+    voucher: Omit<DelegateCallVoucher<Hex | ByteArray>, "type">,
+    to?: To,
+): Hex | ByteArray {
+    return to === "bytes"
         ? encodeDelegateCallVoucherBytes(voucher)
         : encodeFunctionData({
               abi: outputsAbi,
               functionName: "DelegateCallVoucher",
               args: [voucher.destination, asHex(voucher.payload)],
-          })) as EncodedData<to>;
+          });
+}
 
 /**
  * Encode an output as one of the functions of the rollups contracts `Outputs`
@@ -277,10 +308,19 @@ export const encodeDelegateCallVoucher = <to extends To = "hex">(
  * `"bytes"`
  * @returns ABI-encoded output data
  */
-export const encodeOutput = <to extends To = "hex">(
+export function encodeOutput(output: Output<Hex | ByteArray>, to?: "hex"): Hex;
+export function encodeOutput(
     output: Output<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to: "bytes",
+): ByteArray;
+export function encodeOutput(
+    output: Output<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeOutput(
+    output: Output<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     switch (output.type) {
         case "Notice":
             return encodeNotice(output, to);
@@ -289,4 +329,4 @@ export const encodeOutput = <to extends To = "hex">(
         case "DelegateCallVoucher":
             return encodeDelegateCallVoucher(output, to);
     }
-};
+}

--- a/packages/codec/src/portal.ts
+++ b/packages/codec/src/portal.ts
@@ -1,5 +1,6 @@
 import {
     type Address,
+    type ByteArray,
     decodeAbiParameters,
     encodeAbiParameters,
     encodePacked,
@@ -10,6 +11,21 @@ import {
     size,
     slice,
 } from "viem";
+import {
+    abiBytesSize,
+    abiUint256ArraySize,
+    asBytes,
+    asHex,
+    readAbiBytes,
+    readAbiUint256Array,
+    readAddress,
+    readUint256,
+    WORD,
+    writeAbiBytes,
+    writeAbiUint256Array,
+    writeAddress,
+    writeUint256,
+} from "./bytes.js";
 import type { Input } from "./input.js";
 import {
     erc1155BatchPortalAddress,
@@ -18,31 +34,34 @@ import {
     erc721PortalAddress,
     etherPortalAddress,
 } from "./rollups.js";
-import type { Prettify } from "./types.js";
+import type { DecodedBytes, EncodedData, Prettify, To } from "./types.js";
 
 // payloads of portal deposit inputs are packed-encoded (`abi.encodePacked`)
 // by the rollups contracts `InputEncoding` library, so unlike inputs and
 // outputs there is no ABI to decode against; layouts below mirror that
 // library, and sizes are in bytes
 
+// each deposit type takes a `bytes` parameter selecting the representation of
+// its variable-size data fields: `Hex` (the default) or `Uint8Array`
+
 /**
  * Payload of an input added by the Ether portal.
  * Layout: `sender (20) ‖ value (32) ‖ execLayerData`.
  */
-export type EtherDeposit = {
+export type EtherDeposit<bytes extends Hex | ByteArray = Hex> = {
     /** Ether sender */
     sender: Address;
     /** Amount of Wei being sent */
     value: bigint;
     /** Additional data to be interpreted by the execution layer */
-    execLayerData: Hex;
+    execLayerData: bytes;
 };
 
 /**
  * Payload of an input added by the ERC-20 portal.
  * Layout: `token (20) ‖ sender (20) ‖ value (32) ‖ execLayerData`.
  */
-export type Erc20Deposit = {
+export type Erc20Deposit<bytes extends Hex | ByteArray = Hex> = {
     /** Token contract */
     token: Address;
     /** Token sender */
@@ -50,7 +69,7 @@ export type Erc20Deposit = {
     /** Amount of tokens being sent */
     value: bigint;
     /** Additional data to be interpreted by the execution layer */
-    execLayerData: Hex;
+    execLayerData: bytes;
 };
 
 /**
@@ -58,7 +77,7 @@ export type Erc20Deposit = {
  * Layout: `token (20) ‖ sender (20) ‖ tokenId (32) ‖
  * abi.encode(baseLayerData, execLayerData)`.
  */
-export type Erc721Deposit = {
+export type Erc721Deposit<bytes extends Hex | ByteArray = Hex> = {
     /** Token contract */
     token: Address;
     /** Token sender */
@@ -66,9 +85,9 @@ export type Erc721Deposit = {
     /** Token identifier */
     tokenId: bigint;
     /** Additional data to be interpreted by the base layer */
-    baseLayerData: Hex;
+    baseLayerData: bytes;
     /** Additional data to be interpreted by the execution layer */
-    execLayerData: Hex;
+    execLayerData: bytes;
 };
 
 /**
@@ -76,7 +95,7 @@ export type Erc721Deposit = {
  * Layout: `token (20) ‖ sender (20) ‖ tokenId (32) ‖ value (32) ‖
  * abi.encode(baseLayerData, execLayerData)`.
  */
-export type Erc1155SingleDeposit = {
+export type Erc1155SingleDeposit<bytes extends Hex | ByteArray = Hex> = {
     /** Token contract */
     token: Address;
     /** Token sender */
@@ -86,9 +105,9 @@ export type Erc1155SingleDeposit = {
     /** Transfer amount */
     value: bigint;
     /** Additional data to be interpreted by the base layer */
-    baseLayerData: Hex;
+    baseLayerData: bytes;
     /** Additional data to be interpreted by the execution layer */
-    execLayerData: Hex;
+    execLayerData: bytes;
 };
 
 /**
@@ -96,7 +115,7 @@ export type Erc1155SingleDeposit = {
  * Layout: `token (20) ‖ sender (20) ‖
  * abi.encode(tokenIds, values, baseLayerData, execLayerData)`.
  */
-export type Erc1155BatchDeposit = {
+export type Erc1155BatchDeposit<bytes extends Hex | ByteArray = Hex> = {
     /** Token contract */
     token: Address;
     /** Token sender */
@@ -106,9 +125,9 @@ export type Erc1155BatchDeposit = {
     /** Transfer amounts per token type */
     values: readonly bigint[];
     /** Additional data to be interpreted by the base layer */
-    baseLayerData: Hex;
+    baseLayerData: bytes;
     /** Additional data to be interpreted by the execution layer */
-    execLayerData: Hex;
+    execLayerData: bytes;
 };
 
 // abi.encode(baseLayerData, execLayerData) tail of ERC-721/1155 deposits
@@ -123,7 +142,11 @@ const batchDataAbi = [
     { type: "bytes" },
 ] as const;
 
-const assertMinSize = (payload: Hex, min: number, what: string): void => {
+const assertMinSize = (
+    payload: Hex | ByteArray,
+    min: number,
+    what: string,
+): void => {
     if (size(payload) < min) {
         throw new Error(
             `invalid ${what} payload: expected at least ${min} bytes, got ${size(payload)}`,
@@ -134,72 +157,184 @@ const assertMinSize = (payload: Hex, min: number, what: string): void => {
 const sliceFrom = (payload: Hex, start: number): Hex =>
     size(payload) > start ? slice(payload, start) : "0x";
 
+// hand-rolled encoders of the abi.encode'd data tails, filling a
+// preallocated buffer
+
+const dataTailSize = (
+    baseLayerData: ByteArray,
+    execLayerData: ByteArray,
+): number =>
+    2 * WORD + abiBytesSize(baseLayerData) + abiBytesSize(execLayerData);
+
+const writeDataTail = (
+    data: Uint8Array,
+    offset: number,
+    baseLayerData: ByteArray,
+    execLayerData: ByteArray,
+): void => {
+    const baseLayerDataOffset = 2 * WORD;
+    const execLayerDataOffset =
+        baseLayerDataOffset + abiBytesSize(baseLayerData);
+    let next = writeUint256(data, offset, BigInt(baseLayerDataOffset));
+    next = writeUint256(data, next, BigInt(execLayerDataOffset));
+    next = writeAbiBytes(data, next, baseLayerData);
+    writeAbiBytes(data, next, execLayerData);
+};
+
+const batchDataTailSize = (
+    tokenIds: readonly bigint[],
+    values: readonly bigint[],
+    baseLayerData: ByteArray,
+    execLayerData: ByteArray,
+): number =>
+    4 * WORD +
+    abiUint256ArraySize(tokenIds) +
+    abiUint256ArraySize(values) +
+    abiBytesSize(baseLayerData) +
+    abiBytesSize(execLayerData);
+
+const writeBatchDataTail = (
+    data: Uint8Array,
+    offset: number,
+    tokenIds: readonly bigint[],
+    values: readonly bigint[],
+    baseLayerData: ByteArray,
+    execLayerData: ByteArray,
+): void => {
+    const tokenIdsOffset = 4 * WORD;
+    const valuesOffset = tokenIdsOffset + abiUint256ArraySize(tokenIds);
+    const baseLayerDataOffset = valuesOffset + abiUint256ArraySize(values);
+    const execLayerDataOffset =
+        baseLayerDataOffset + abiBytesSize(baseLayerData);
+    let next = writeUint256(data, offset, BigInt(tokenIdsOffset));
+    next = writeUint256(data, next, BigInt(valuesOffset));
+    next = writeUint256(data, next, BigInt(baseLayerDataOffset));
+    next = writeUint256(data, next, BigInt(execLayerDataOffset));
+    next = writeAbiUint256Array(data, next, tokenIds);
+    next = writeAbiUint256Array(data, next, values);
+    next = writeAbiBytes(data, next, baseLayerData);
+    writeAbiBytes(data, next, execLayerData);
+};
+
 /**
  * Decode the payload of an input added by the Ether portal.
  * @param payload packed-encoded deposit payload (the `payload` field of a
- * decoded input)
- * @returns decoded Ether deposit
+ * decoded input), as a hex string or byte array
+ * @returns decoded Ether deposit; `execLayerData` follows the representation
+ * of `payload`, and is a zero-copy subarray when `payload` is a byte array
  * @throws if the payload is too short
  */
-export const decodeEtherDeposit = (payload: Hex): EtherDeposit => {
-    assertMinSize(payload, 52, "Ether deposit");
-    return {
-        sender: getAddress(slice(payload, 0, 20)),
-        value: hexToBigInt(slice(payload, 20, 52)),
-        execLayerData: sliceFrom(payload, 52),
-    };
+export const decodeEtherDeposit = <data extends Hex | ByteArray>(
+    payload: data,
+): EtherDeposit<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = payload;
+    assertMinSize(blob, 52, "Ether deposit");
+    return (
+        typeof blob === "string"
+            ? {
+                  sender: getAddress(slice(blob, 0, 20)),
+                  value: hexToBigInt(slice(blob, 20, 52)),
+                  execLayerData: sliceFrom(blob, 52),
+              }
+            : {
+                  sender: readAddress(blob, 0),
+                  value: readUint256(blob, 20),
+                  execLayerData: blob.subarray(52),
+              }
+    ) as EtherDeposit<DecodedBytes<data>>;
 };
 
 /**
  * Encode an Ether deposit as the Ether portal does. This is the inverse of
  * `decodeEtherDeposit`, useful for testing.
- * @param deposit Ether deposit to encode
+ * @param deposit Ether deposit to encode; `execLayerData` may be a hex string
+ * or byte array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeEtherDeposit = (deposit: EtherDeposit): Hex =>
-    encodePacked(
+export const encodeEtherDeposit = <to extends To = "hex">(
+    deposit: EtherDeposit<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
+    if (to === "bytes") {
+        const execLayerData = asBytes(deposit.execLayerData);
+        const data = new Uint8Array(52 + execLayerData.length);
+        let offset = writeAddress(data, 0, deposit.sender);
+        offset = writeUint256(data, offset, deposit.value);
+        data.set(execLayerData, offset);
+        return data as EncodedData<to>;
+    }
+    return encodePacked(
         ["address", "uint256", "bytes"],
-        [deposit.sender, deposit.value, deposit.execLayerData],
-    );
+        [deposit.sender, deposit.value, asHex(deposit.execLayerData)],
+    ) as EncodedData<to>;
+};
 
 /**
  * Decode the payload of an input added by the ERC-20 portal.
  * @param payload packed-encoded deposit payload (the `payload` field of a
- * decoded input)
- * @returns decoded ERC-20 deposit
+ * decoded input), as a hex string or byte array
+ * @returns decoded ERC-20 deposit; `execLayerData` follows the representation
+ * of `payload`, and is a zero-copy subarray when `payload` is a byte array
  * @throws if the payload is too short
  */
-export const decodeErc20Deposit = (payload: Hex): Erc20Deposit => {
-    assertMinSize(payload, 72, "ERC-20 deposit");
-    return {
-        token: getAddress(slice(payload, 0, 20)),
-        sender: getAddress(slice(payload, 20, 40)),
-        value: hexToBigInt(slice(payload, 40, 72)),
-        execLayerData: sliceFrom(payload, 72),
-    };
+export const decodeErc20Deposit = <data extends Hex | ByteArray>(
+    payload: data,
+): Erc20Deposit<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = payload;
+    assertMinSize(blob, 72, "ERC-20 deposit");
+    return (
+        typeof blob === "string"
+            ? {
+                  token: getAddress(slice(blob, 0, 20)),
+                  sender: getAddress(slice(blob, 20, 40)),
+                  value: hexToBigInt(slice(blob, 40, 72)),
+                  execLayerData: sliceFrom(blob, 72),
+              }
+            : {
+                  token: readAddress(blob, 0),
+                  sender: readAddress(blob, 20),
+                  value: readUint256(blob, 40),
+                  execLayerData: blob.subarray(72),
+              }
+    ) as Erc20Deposit<DecodedBytes<data>>;
 };
 
 /**
  * Encode an ERC-20 deposit as the ERC-20 portal does. This is the inverse of
  * `decodeErc20Deposit`, useful for testing.
- * @param deposit ERC-20 deposit to encode
+ * @param deposit ERC-20 deposit to encode; `execLayerData` may be a hex
+ * string or byte array
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc20Deposit = (deposit: Erc20Deposit): Hex =>
-    encodePacked(
+export const encodeErc20Deposit = <to extends To = "hex">(
+    deposit: Erc20Deposit<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
+    if (to === "bytes") {
+        const execLayerData = asBytes(deposit.execLayerData);
+        const data = new Uint8Array(72 + execLayerData.length);
+        let offset = writeAddress(data, 0, deposit.token);
+        offset = writeAddress(data, offset, deposit.sender);
+        offset = writeUint256(data, offset, deposit.value);
+        data.set(execLayerData, offset);
+        return data as EncodedData<to>;
+    }
+    return encodePacked(
         ["address", "address", "uint256", "bytes"],
-        [deposit.token, deposit.sender, deposit.value, deposit.execLayerData],
-    );
+        [
+            deposit.token,
+            deposit.sender,
+            deposit.value,
+            asHex(deposit.execLayerData),
+        ],
+    ) as EncodedData<to>;
+};
 
-/**
- * Decode the payload of an input added by the ERC-721 portal.
- * @param payload packed-encoded deposit payload (the `payload` field of a
- * decoded input)
- * @returns decoded ERC-721 deposit
- * @throws if the payload is too short or its data tail is malformed
- */
-export const decodeErc721Deposit = (payload: Hex): Erc721Deposit => {
-    assertMinSize(payload, 72, "ERC-721 deposit");
+const decodeErc721DepositHex = (payload: Hex): Erc721Deposit => {
     const [baseLayerData, execLayerData] = decodeAbiParameters(
         dataAbi,
         sliceFrom(payload, 72),
@@ -213,37 +348,76 @@ export const decodeErc721Deposit = (payload: Hex): Erc721Deposit => {
     };
 };
 
+const decodeErc721DepositBytes = (
+    payload: ByteArray,
+): Erc721Deposit<ByteArray> => ({
+    token: readAddress(payload, 0),
+    sender: readAddress(payload, 20),
+    tokenId: readUint256(payload, 40),
+    baseLayerData: readAbiBytes(payload, 72, 72),
+    execLayerData: readAbiBytes(payload, 72, 72 + WORD),
+});
+
+/**
+ * Decode the payload of an input added by the ERC-721 portal.
+ * @param payload packed-encoded deposit payload (the `payload` field of a
+ * decoded input), as a hex string or byte array
+ * @returns decoded ERC-721 deposit; the data fields follow the representation
+ * of `payload`, and are zero-copy subarrays when `payload` is a byte array
+ * @throws if the payload is too short or its data tail is malformed
+ */
+export const decodeErc721Deposit = <data extends Hex | ByteArray>(
+    payload: data,
+): Erc721Deposit<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = payload;
+    assertMinSize(blob, 72, "ERC-721 deposit");
+    return (
+        typeof blob === "string"
+            ? decodeErc721DepositHex(blob)
+            : decodeErc721DepositBytes(blob)
+    ) as Erc721Deposit<DecodedBytes<data>>;
+};
+
 /**
  * Encode an ERC-721 deposit as the ERC-721 portal does. This is the inverse
  * of `decodeErc721Deposit`, useful for testing.
- * @param deposit ERC-721 deposit to encode
+ * @param deposit ERC-721 deposit to encode; the data fields may be hex
+ * strings or byte arrays
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc721Deposit = (deposit: Erc721Deposit): Hex =>
-    encodePacked(
+export const encodeErc721Deposit = <to extends To = "hex">(
+    deposit: Erc721Deposit<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
+    if (to === "bytes") {
+        const baseLayerData = asBytes(deposit.baseLayerData);
+        const execLayerData = asBytes(deposit.execLayerData);
+        const data = new Uint8Array(
+            72 + dataTailSize(baseLayerData, execLayerData),
+        );
+        let offset = writeAddress(data, 0, deposit.token);
+        offset = writeAddress(data, offset, deposit.sender);
+        offset = writeUint256(data, offset, deposit.tokenId);
+        writeDataTail(data, offset, baseLayerData, execLayerData);
+        return data as EncodedData<to>;
+    }
+    return encodePacked(
         ["address", "address", "uint256", "bytes"],
         [
             deposit.token,
             deposit.sender,
             deposit.tokenId,
             encodeAbiParameters(dataAbi, [
-                deposit.baseLayerData,
-                deposit.execLayerData,
+                asHex(deposit.baseLayerData),
+                asHex(deposit.execLayerData),
             ]),
         ],
-    );
+    ) as EncodedData<to>;
+};
 
-/**
- * Decode the payload of an input added by the ERC-1155 single portal.
- * @param payload packed-encoded deposit payload (the `payload` field of a
- * decoded input)
- * @returns decoded ERC-1155 single deposit
- * @throws if the payload is too short or its data tail is malformed
- */
-export const decodeErc1155SingleDeposit = (
-    payload: Hex,
-): Erc1155SingleDeposit => {
-    assertMinSize(payload, 104, "ERC-1155 single deposit");
+const decodeErc1155SingleDepositHex = (payload: Hex): Erc1155SingleDeposit => {
     const [baseLayerData, execLayerData] = decodeAbiParameters(
         dataAbi,
         sliceFrom(payload, 104),
@@ -258,16 +432,65 @@ export const decodeErc1155SingleDeposit = (
     };
 };
 
+const decodeErc1155SingleDepositBytes = (
+    payload: ByteArray,
+): Erc1155SingleDeposit<ByteArray> => ({
+    token: readAddress(payload, 0),
+    sender: readAddress(payload, 20),
+    tokenId: readUint256(payload, 40),
+    value: readUint256(payload, 72),
+    baseLayerData: readAbiBytes(payload, 104, 104),
+    execLayerData: readAbiBytes(payload, 104, 104 + WORD),
+});
+
+/**
+ * Decode the payload of an input added by the ERC-1155 single portal.
+ * @param payload packed-encoded deposit payload (the `payload` field of a
+ * decoded input), as a hex string or byte array
+ * @returns decoded ERC-1155 single deposit; the data fields follow the
+ * representation of `payload`, and are zero-copy subarrays when `payload` is
+ * a byte array
+ * @throws if the payload is too short or its data tail is malformed
+ */
+export const decodeErc1155SingleDeposit = <data extends Hex | ByteArray>(
+    payload: data,
+): Erc1155SingleDeposit<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = payload;
+    assertMinSize(blob, 104, "ERC-1155 single deposit");
+    return (
+        typeof blob === "string"
+            ? decodeErc1155SingleDepositHex(blob)
+            : decodeErc1155SingleDepositBytes(blob)
+    ) as Erc1155SingleDeposit<DecodedBytes<data>>;
+};
+
 /**
  * Encode an ERC-1155 single deposit as the ERC-1155 single portal does. This
  * is the inverse of `decodeErc1155SingleDeposit`, useful for testing.
- * @param deposit ERC-1155 single deposit to encode
+ * @param deposit ERC-1155 single deposit to encode; the data fields may be
+ * hex strings or byte arrays
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc1155SingleDeposit = (
-    deposit: Erc1155SingleDeposit,
-): Hex =>
-    encodePacked(
+export const encodeErc1155SingleDeposit = <to extends To = "hex">(
+    deposit: Erc1155SingleDeposit<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
+    if (to === "bytes") {
+        const baseLayerData = asBytes(deposit.baseLayerData);
+        const execLayerData = asBytes(deposit.execLayerData);
+        const data = new Uint8Array(
+            104 + dataTailSize(baseLayerData, execLayerData),
+        );
+        let offset = writeAddress(data, 0, deposit.token);
+        offset = writeAddress(data, offset, deposit.sender);
+        offset = writeUint256(data, offset, deposit.tokenId);
+        offset = writeUint256(data, offset, deposit.value);
+        writeDataTail(data, offset, baseLayerData, execLayerData);
+        return data as EncodedData<to>;
+    }
+    return encodePacked(
         ["address", "address", "uint256", "uint256", "bytes"],
         [
             deposit.token,
@@ -275,23 +498,14 @@ export const encodeErc1155SingleDeposit = (
             deposit.tokenId,
             deposit.value,
             encodeAbiParameters(dataAbi, [
-                deposit.baseLayerData,
-                deposit.execLayerData,
+                asHex(deposit.baseLayerData),
+                asHex(deposit.execLayerData),
             ]),
         ],
-    );
+    ) as EncodedData<to>;
+};
 
-/**
- * Decode the payload of an input added by the ERC-1155 batch portal.
- * @param payload packed-encoded deposit payload (the `payload` field of a
- * decoded input)
- * @returns decoded ERC-1155 batch deposit
- * @throws if the payload is too short or its data tail is malformed
- */
-export const decodeErc1155BatchDeposit = (
-    payload: Hex,
-): Erc1155BatchDeposit => {
-    assertMinSize(payload, 40, "ERC-1155 batch deposit");
+const decodeErc1155BatchDepositHex = (payload: Hex): Erc1155BatchDeposit => {
     const [tokenIds, values, baseLayerData, execLayerData] =
         decodeAbiParameters(batchDataAbi, sliceFrom(payload, 40));
     return {
@@ -304,14 +518,76 @@ export const decodeErc1155BatchDeposit = (
     };
 };
 
+const decodeErc1155BatchDepositBytes = (
+    payload: ByteArray,
+): Erc1155BatchDeposit<ByteArray> => ({
+    token: readAddress(payload, 0),
+    sender: readAddress(payload, 20),
+    tokenIds: readAbiUint256Array(payload, 40, 40),
+    values: readAbiUint256Array(payload, 40, 40 + WORD),
+    baseLayerData: readAbiBytes(payload, 40, 40 + 2 * WORD),
+    execLayerData: readAbiBytes(payload, 40, 40 + 3 * WORD),
+});
+
+/**
+ * Decode the payload of an input added by the ERC-1155 batch portal.
+ * @param payload packed-encoded deposit payload (the `payload` field of a
+ * decoded input), as a hex string or byte array
+ * @returns decoded ERC-1155 batch deposit; the data fields follow the
+ * representation of `payload`, and are zero-copy subarrays when `payload` is
+ * a byte array
+ * @throws if the payload is too short or its data tail is malformed
+ */
+export const decodeErc1155BatchDeposit = <data extends Hex | ByteArray>(
+    payload: data,
+): Erc1155BatchDeposit<DecodedBytes<data>> => {
+    const blob: Hex | ByteArray = payload;
+    assertMinSize(blob, 40, "ERC-1155 batch deposit");
+    return (
+        typeof blob === "string"
+            ? decodeErc1155BatchDepositHex(blob)
+            : decodeErc1155BatchDepositBytes(blob)
+    ) as Erc1155BatchDeposit<DecodedBytes<data>>;
+};
+
 /**
  * Encode an ERC-1155 batch deposit as the ERC-1155 batch portal does. This is
  * the inverse of `decodeErc1155BatchDeposit`, useful for testing.
- * @param deposit ERC-1155 batch deposit to encode
+ * @param deposit ERC-1155 batch deposit to encode; the data fields may be hex
+ * strings or byte arrays
+ * @param to representation of the encoded data: `"hex"` (the default) or
+ * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc1155BatchDeposit = (deposit: Erc1155BatchDeposit): Hex =>
-    encodePacked(
+export const encodeErc1155BatchDeposit = <to extends To = "hex">(
+    deposit: Erc1155BatchDeposit<Hex | ByteArray>,
+    to?: to,
+): EncodedData<to> => {
+    if (to === "bytes") {
+        const baseLayerData = asBytes(deposit.baseLayerData);
+        const execLayerData = asBytes(deposit.execLayerData);
+        const data = new Uint8Array(
+            40 +
+                batchDataTailSize(
+                    deposit.tokenIds,
+                    deposit.values,
+                    baseLayerData,
+                    execLayerData,
+                ),
+        );
+        let offset = writeAddress(data, 0, deposit.token);
+        offset = writeAddress(data, offset, deposit.sender);
+        writeBatchDataTail(
+            data,
+            offset,
+            deposit.tokenIds,
+            deposit.values,
+            baseLayerData,
+            execLayerData,
+        );
+        return data as EncodedData<to>;
+    }
+    return encodePacked(
         ["address", "address", "bytes"],
         [
             deposit.token,
@@ -319,37 +595,29 @@ export const encodeErc1155BatchDeposit = (deposit: Erc1155BatchDeposit): Hex =>
             encodeAbiParameters(batchDataAbi, [
                 deposit.tokenIds,
                 deposit.values,
-                deposit.baseLayerData,
-                deposit.execLayerData,
+                asHex(deposit.baseLayerData),
+                asHex(deposit.execLayerData),
             ]),
         ],
-    );
+    ) as EncodedData<to>;
+};
 
 /**
  * Deposit made through one of the rollups portals, discriminated by the
  * `type` field.
  */
-export type Deposit = Prettify<
-    | ({ type: "Erc1155BatchDeposit" } & Erc1155BatchDeposit)
-    | ({ type: "Erc20Deposit" } & Erc20Deposit)
-    | ({ type: "Erc721Deposit" } & Erc721Deposit)
-    | ({ type: "EtherDeposit" } & EtherDeposit)
-    | ({ type: "Erc1155SingleDeposit" } & Erc1155SingleDeposit)
+export type Deposit<bytes extends Hex | ByteArray = Hex> = Prettify<
+    | ({ type: "Erc1155BatchDeposit" } & Erc1155BatchDeposit<bytes>)
+    | ({ type: "Erc20Deposit" } & Erc20Deposit<bytes>)
+    | ({ type: "Erc721Deposit" } & Erc721Deposit<bytes>)
+    | ({ type: "EtherDeposit" } & EtherDeposit<bytes>)
+    | ({ type: "Erc1155SingleDeposit" } & Erc1155SingleDeposit<bytes>)
 >;
 
-/**
- * Decode the payload of an input as a portal deposit, dispatching on the
- * input's `msgSender`: if it is one of the portal deployment addresses, the
- * payload is decoded with the corresponding decode function.
- * @param input decoded input (only `msgSender` and `payload` are used)
- * @returns decoded deposit, discriminated by the `type` field, or `undefined`
- * if `msgSender` is not a portal (i.e. the input is not a deposit)
- * @throws if `msgSender` is a portal but the payload is malformed
- */
-export const decodeDeposit = (
-    input: Pick<Input, "msgSender" | "payload">,
-): Deposit | undefined => {
-    const { msgSender, payload } = input;
+const dispatchDeposit = (
+    msgSender: Address,
+    payload: Hex | ByteArray,
+): Deposit<Hex | ByteArray> | undefined => {
     if (isAddressEqual(msgSender, etherPortalAddress)) {
         return { type: "EtherDeposit", ...decodeEtherDeposit(payload) };
     }
@@ -373,3 +641,22 @@ export const decodeDeposit = (
     }
     return undefined;
 };
+
+/**
+ * Decode the payload of an input as a portal deposit, dispatching on the
+ * input's `msgSender`: if it is one of the portal deployment addresses, the
+ * payload is decoded with the corresponding decode function.
+ * @param input decoded input (only `msgSender` and `payload` are used); the
+ * `payload` may be a hex string or byte array
+ * @returns decoded deposit, discriminated by the `type` field, or `undefined`
+ * if `msgSender` is not a portal (i.e. the input is not a deposit); the data
+ * fields follow the representation of the `payload`, and are zero-copy
+ * subarrays when the `payload` is a byte array
+ * @throws if `msgSender` is a portal but the payload is malformed
+ */
+export const decodeDeposit = <data extends Hex | ByteArray>(
+    input: Pick<Input<data>, "msgSender" | "payload">,
+): Deposit<DecodedBytes<data>> | undefined =>
+    dispatchDeposit(input.msgSender, input.payload) as
+        | Deposit<DecodedBytes<data>>
+        | undefined;

--- a/packages/codec/src/portal.ts
+++ b/packages/codec/src/portal.ts
@@ -34,7 +34,7 @@ import {
     erc721PortalAddress,
     etherPortalAddress,
 } from "./rollups.js";
-import type { DecodedBytes, EncodedData, Prettify, To } from "./types.js";
+import type { Prettify, To } from "./types.js";
 
 // payloads of portal deposit inputs are packed-encoded (`abi.encodePacked`)
 // by the rollups contracts `InputEncoding` library, so unlike inputs and
@@ -216,6 +216,20 @@ const writeBatchDataTail = (
     writeAbiBytes(data, next, execLayerData);
 };
 
+const decodeEtherDepositHex = (payload: Hex): EtherDeposit => ({
+    sender: getAddress(slice(payload, 0, 20)),
+    value: hexToBigInt(slice(payload, 20, 52)),
+    execLayerData: sliceFrom(payload, 52),
+});
+
+const decodeEtherDepositBytes = (
+    payload: ByteArray,
+): EtherDeposit<ByteArray> => ({
+    sender: readAddress(payload, 0),
+    value: readUint256(payload, 20),
+    execLayerData: payload.subarray(52),
+});
+
 /**
  * Decode the payload of an input added by the Ether portal.
  * @param payload packed-encoded deposit payload (the `payload` field of a
@@ -224,25 +238,19 @@ const writeBatchDataTail = (
  * of `payload`, and is a zero-copy subarray when `payload` is a byte array
  * @throws if the payload is too short
  */
-export const decodeEtherDeposit = <data extends Hex | ByteArray>(
-    payload: data,
-): EtherDeposit<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = payload;
-    assertMinSize(blob, 52, "Ether deposit");
-    return (
-        typeof blob === "string"
-            ? {
-                  sender: getAddress(slice(blob, 0, 20)),
-                  value: hexToBigInt(slice(blob, 20, 52)),
-                  execLayerData: sliceFrom(blob, 52),
-              }
-            : {
-                  sender: readAddress(blob, 0),
-                  value: readUint256(blob, 20),
-                  execLayerData: blob.subarray(52),
-              }
-    ) as EtherDeposit<DecodedBytes<data>>;
-};
+export function decodeEtherDeposit(payload: Hex): EtherDeposit;
+export function decodeEtherDeposit(payload: ByteArray): EtherDeposit<ByteArray>;
+export function decodeEtherDeposit(
+    payload: Hex | ByteArray,
+): EtherDeposit<Hex | ByteArray>;
+export function decodeEtherDeposit(
+    payload: Hex | ByteArray,
+): EtherDeposit<Hex | ByteArray> {
+    assertMinSize(payload, 52, "Ether deposit");
+    return typeof payload === "string"
+        ? decodeEtherDepositHex(payload)
+        : decodeEtherDepositBytes(payload);
+}
 
 /**
  * Encode an Ether deposit as the Ether portal does. This is the inverse of
@@ -253,23 +261,51 @@ export const decodeEtherDeposit = <data extends Hex | ByteArray>(
  * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeEtherDeposit = <to extends To = "hex">(
+export function encodeEtherDeposit(
     deposit: EtherDeposit<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to?: "hex",
+): Hex;
+export function encodeEtherDeposit(
+    deposit: EtherDeposit<Hex | ByteArray>,
+    to: "bytes",
+): ByteArray;
+export function encodeEtherDeposit(
+    deposit: EtherDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeEtherDeposit(
+    deposit: EtherDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     if (to === "bytes") {
         const execLayerData = asBytes(deposit.execLayerData);
         const data = new Uint8Array(52 + execLayerData.length);
         let offset = writeAddress(data, 0, deposit.sender);
         offset = writeUint256(data, offset, deposit.value);
         data.set(execLayerData, offset);
-        return data as EncodedData<to>;
+        return data;
     }
     return encodePacked(
         ["address", "uint256", "bytes"],
         [deposit.sender, deposit.value, asHex(deposit.execLayerData)],
-    ) as EncodedData<to>;
-};
+    );
+}
+
+const decodeErc20DepositHex = (payload: Hex): Erc20Deposit => ({
+    token: getAddress(slice(payload, 0, 20)),
+    sender: getAddress(slice(payload, 20, 40)),
+    value: hexToBigInt(slice(payload, 40, 72)),
+    execLayerData: sliceFrom(payload, 72),
+});
+
+const decodeErc20DepositBytes = (
+    payload: ByteArray,
+): Erc20Deposit<ByteArray> => ({
+    token: readAddress(payload, 0),
+    sender: readAddress(payload, 20),
+    value: readUint256(payload, 40),
+    execLayerData: payload.subarray(72),
+});
 
 /**
  * Decode the payload of an input added by the ERC-20 portal.
@@ -279,27 +315,19 @@ export const encodeEtherDeposit = <to extends To = "hex">(
  * of `payload`, and is a zero-copy subarray when `payload` is a byte array
  * @throws if the payload is too short
  */
-export const decodeErc20Deposit = <data extends Hex | ByteArray>(
-    payload: data,
-): Erc20Deposit<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = payload;
-    assertMinSize(blob, 72, "ERC-20 deposit");
-    return (
-        typeof blob === "string"
-            ? {
-                  token: getAddress(slice(blob, 0, 20)),
-                  sender: getAddress(slice(blob, 20, 40)),
-                  value: hexToBigInt(slice(blob, 40, 72)),
-                  execLayerData: sliceFrom(blob, 72),
-              }
-            : {
-                  token: readAddress(blob, 0),
-                  sender: readAddress(blob, 20),
-                  value: readUint256(blob, 40),
-                  execLayerData: blob.subarray(72),
-              }
-    ) as Erc20Deposit<DecodedBytes<data>>;
-};
+export function decodeErc20Deposit(payload: Hex): Erc20Deposit;
+export function decodeErc20Deposit(payload: ByteArray): Erc20Deposit<ByteArray>;
+export function decodeErc20Deposit(
+    payload: Hex | ByteArray,
+): Erc20Deposit<Hex | ByteArray>;
+export function decodeErc20Deposit(
+    payload: Hex | ByteArray,
+): Erc20Deposit<Hex | ByteArray> {
+    assertMinSize(payload, 72, "ERC-20 deposit");
+    return typeof payload === "string"
+        ? decodeErc20DepositHex(payload)
+        : decodeErc20DepositBytes(payload);
+}
 
 /**
  * Encode an ERC-20 deposit as the ERC-20 portal does. This is the inverse of
@@ -310,10 +338,22 @@ export const decodeErc20Deposit = <data extends Hex | ByteArray>(
  * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc20Deposit = <to extends To = "hex">(
+export function encodeErc20Deposit(
     deposit: Erc20Deposit<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to?: "hex",
+): Hex;
+export function encodeErc20Deposit(
+    deposit: Erc20Deposit<Hex | ByteArray>,
+    to: "bytes",
+): ByteArray;
+export function encodeErc20Deposit(
+    deposit: Erc20Deposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeErc20Deposit(
+    deposit: Erc20Deposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     if (to === "bytes") {
         const execLayerData = asBytes(deposit.execLayerData);
         const data = new Uint8Array(72 + execLayerData.length);
@@ -321,7 +361,7 @@ export const encodeErc20Deposit = <to extends To = "hex">(
         offset = writeAddress(data, offset, deposit.sender);
         offset = writeUint256(data, offset, deposit.value);
         data.set(execLayerData, offset);
-        return data as EncodedData<to>;
+        return data;
     }
     return encodePacked(
         ["address", "address", "uint256", "bytes"],
@@ -331,8 +371,8 @@ export const encodeErc20Deposit = <to extends To = "hex">(
             deposit.value,
             asHex(deposit.execLayerData),
         ],
-    ) as EncodedData<to>;
-};
+    );
+}
 
 const decodeErc721DepositHex = (payload: Hex): Erc721Deposit => {
     const [baseLayerData, execLayerData] = decodeAbiParameters(
@@ -366,17 +406,21 @@ const decodeErc721DepositBytes = (
  * of `payload`, and are zero-copy subarrays when `payload` is a byte array
  * @throws if the payload is too short or its data tail is malformed
  */
-export const decodeErc721Deposit = <data extends Hex | ByteArray>(
-    payload: data,
-): Erc721Deposit<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = payload;
-    assertMinSize(blob, 72, "ERC-721 deposit");
-    return (
-        typeof blob === "string"
-            ? decodeErc721DepositHex(blob)
-            : decodeErc721DepositBytes(blob)
-    ) as Erc721Deposit<DecodedBytes<data>>;
-};
+export function decodeErc721Deposit(payload: Hex): Erc721Deposit;
+export function decodeErc721Deposit(
+    payload: ByteArray,
+): Erc721Deposit<ByteArray>;
+export function decodeErc721Deposit(
+    payload: Hex | ByteArray,
+): Erc721Deposit<Hex | ByteArray>;
+export function decodeErc721Deposit(
+    payload: Hex | ByteArray,
+): Erc721Deposit<Hex | ByteArray> {
+    assertMinSize(payload, 72, "ERC-721 deposit");
+    return typeof payload === "string"
+        ? decodeErc721DepositHex(payload)
+        : decodeErc721DepositBytes(payload);
+}
 
 /**
  * Encode an ERC-721 deposit as the ERC-721 portal does. This is the inverse
@@ -387,10 +431,22 @@ export const decodeErc721Deposit = <data extends Hex | ByteArray>(
  * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc721Deposit = <to extends To = "hex">(
+export function encodeErc721Deposit(
     deposit: Erc721Deposit<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to?: "hex",
+): Hex;
+export function encodeErc721Deposit(
+    deposit: Erc721Deposit<Hex | ByteArray>,
+    to: "bytes",
+): ByteArray;
+export function encodeErc721Deposit(
+    deposit: Erc721Deposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeErc721Deposit(
+    deposit: Erc721Deposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     if (to === "bytes") {
         const baseLayerData = asBytes(deposit.baseLayerData);
         const execLayerData = asBytes(deposit.execLayerData);
@@ -401,7 +457,7 @@ export const encodeErc721Deposit = <to extends To = "hex">(
         offset = writeAddress(data, offset, deposit.sender);
         offset = writeUint256(data, offset, deposit.tokenId);
         writeDataTail(data, offset, baseLayerData, execLayerData);
-        return data as EncodedData<to>;
+        return data;
     }
     return encodePacked(
         ["address", "address", "uint256", "bytes"],
@@ -414,8 +470,8 @@ export const encodeErc721Deposit = <to extends To = "hex">(
                 asHex(deposit.execLayerData),
             ]),
         ],
-    ) as EncodedData<to>;
-};
+    );
+}
 
 const decodeErc1155SingleDepositHex = (payload: Hex): Erc1155SingleDeposit => {
     const [baseLayerData, execLayerData] = decodeAbiParameters(
@@ -452,17 +508,21 @@ const decodeErc1155SingleDepositBytes = (
  * a byte array
  * @throws if the payload is too short or its data tail is malformed
  */
-export const decodeErc1155SingleDeposit = <data extends Hex | ByteArray>(
-    payload: data,
-): Erc1155SingleDeposit<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = payload;
-    assertMinSize(blob, 104, "ERC-1155 single deposit");
-    return (
-        typeof blob === "string"
-            ? decodeErc1155SingleDepositHex(blob)
-            : decodeErc1155SingleDepositBytes(blob)
-    ) as Erc1155SingleDeposit<DecodedBytes<data>>;
-};
+export function decodeErc1155SingleDeposit(payload: Hex): Erc1155SingleDeposit;
+export function decodeErc1155SingleDeposit(
+    payload: ByteArray,
+): Erc1155SingleDeposit<ByteArray>;
+export function decodeErc1155SingleDeposit(
+    payload: Hex | ByteArray,
+): Erc1155SingleDeposit<Hex | ByteArray>;
+export function decodeErc1155SingleDeposit(
+    payload: Hex | ByteArray,
+): Erc1155SingleDeposit<Hex | ByteArray> {
+    assertMinSize(payload, 104, "ERC-1155 single deposit");
+    return typeof payload === "string"
+        ? decodeErc1155SingleDepositHex(payload)
+        : decodeErc1155SingleDepositBytes(payload);
+}
 
 /**
  * Encode an ERC-1155 single deposit as the ERC-1155 single portal does. This
@@ -473,10 +533,22 @@ export const decodeErc1155SingleDeposit = <data extends Hex | ByteArray>(
  * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc1155SingleDeposit = <to extends To = "hex">(
+export function encodeErc1155SingleDeposit(
     deposit: Erc1155SingleDeposit<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to?: "hex",
+): Hex;
+export function encodeErc1155SingleDeposit(
+    deposit: Erc1155SingleDeposit<Hex | ByteArray>,
+    to: "bytes",
+): ByteArray;
+export function encodeErc1155SingleDeposit(
+    deposit: Erc1155SingleDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeErc1155SingleDeposit(
+    deposit: Erc1155SingleDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     if (to === "bytes") {
         const baseLayerData = asBytes(deposit.baseLayerData);
         const execLayerData = asBytes(deposit.execLayerData);
@@ -488,7 +560,7 @@ export const encodeErc1155SingleDeposit = <to extends To = "hex">(
         offset = writeUint256(data, offset, deposit.tokenId);
         offset = writeUint256(data, offset, deposit.value);
         writeDataTail(data, offset, baseLayerData, execLayerData);
-        return data as EncodedData<to>;
+        return data;
     }
     return encodePacked(
         ["address", "address", "uint256", "uint256", "bytes"],
@@ -502,8 +574,8 @@ export const encodeErc1155SingleDeposit = <to extends To = "hex">(
                 asHex(deposit.execLayerData),
             ]),
         ],
-    ) as EncodedData<to>;
-};
+    );
+}
 
 const decodeErc1155BatchDepositHex = (payload: Hex): Erc1155BatchDeposit => {
     const [tokenIds, values, baseLayerData, execLayerData] =
@@ -538,17 +610,21 @@ const decodeErc1155BatchDepositBytes = (
  * a byte array
  * @throws if the payload is too short or its data tail is malformed
  */
-export const decodeErc1155BatchDeposit = <data extends Hex | ByteArray>(
-    payload: data,
-): Erc1155BatchDeposit<DecodedBytes<data>> => {
-    const blob: Hex | ByteArray = payload;
-    assertMinSize(blob, 40, "ERC-1155 batch deposit");
-    return (
-        typeof blob === "string"
-            ? decodeErc1155BatchDepositHex(blob)
-            : decodeErc1155BatchDepositBytes(blob)
-    ) as Erc1155BatchDeposit<DecodedBytes<data>>;
-};
+export function decodeErc1155BatchDeposit(payload: Hex): Erc1155BatchDeposit;
+export function decodeErc1155BatchDeposit(
+    payload: ByteArray,
+): Erc1155BatchDeposit<ByteArray>;
+export function decodeErc1155BatchDeposit(
+    payload: Hex | ByteArray,
+): Erc1155BatchDeposit<Hex | ByteArray>;
+export function decodeErc1155BatchDeposit(
+    payload: Hex | ByteArray,
+): Erc1155BatchDeposit<Hex | ByteArray> {
+    assertMinSize(payload, 40, "ERC-1155 batch deposit");
+    return typeof payload === "string"
+        ? decodeErc1155BatchDepositHex(payload)
+        : decodeErc1155BatchDepositBytes(payload);
+}
 
 /**
  * Encode an ERC-1155 batch deposit as the ERC-1155 batch portal does. This is
@@ -559,10 +635,22 @@ export const decodeErc1155BatchDeposit = <data extends Hex | ByteArray>(
  * `"bytes"`
  * @returns packed-encoded deposit payload
  */
-export const encodeErc1155BatchDeposit = <to extends To = "hex">(
+export function encodeErc1155BatchDeposit(
     deposit: Erc1155BatchDeposit<Hex | ByteArray>,
-    to?: to,
-): EncodedData<to> => {
+    to?: "hex",
+): Hex;
+export function encodeErc1155BatchDeposit(
+    deposit: Erc1155BatchDeposit<Hex | ByteArray>,
+    to: "bytes",
+): ByteArray;
+export function encodeErc1155BatchDeposit(
+    deposit: Erc1155BatchDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray;
+export function encodeErc1155BatchDeposit(
+    deposit: Erc1155BatchDeposit<Hex | ByteArray>,
+    to?: To,
+): Hex | ByteArray {
     if (to === "bytes") {
         const baseLayerData = asBytes(deposit.baseLayerData);
         const execLayerData = asBytes(deposit.execLayerData);
@@ -585,7 +673,7 @@ export const encodeErc1155BatchDeposit = <to extends To = "hex">(
             baseLayerData,
             execLayerData,
         );
-        return data as EncodedData<to>;
+        return data;
     }
     return encodePacked(
         ["address", "address", "bytes"],
@@ -599,8 +687,8 @@ export const encodeErc1155BatchDeposit = <to extends To = "hex">(
                 asHex(deposit.execLayerData),
             ]),
         ],
-    ) as EncodedData<to>;
-};
+    );
+}
 
 /**
  * Deposit made through one of the rollups portals, discriminated by the
@@ -614,10 +702,31 @@ export type Deposit<bytes extends Hex | ByteArray = Hex> = Prettify<
     | ({ type: "Erc1155SingleDeposit" } & Erc1155SingleDeposit<bytes>)
 >;
 
-const dispatchDeposit = (
-    msgSender: Address,
-    payload: Hex | ByteArray,
-): Deposit<Hex | ByteArray> | undefined => {
+/**
+ * Decode the payload of an input as a portal deposit, dispatching on the
+ * input's `msgSender`: if it is one of the portal deployment addresses, the
+ * payload is decoded with the corresponding decode function.
+ * @param input decoded input (only `msgSender` and `payload` are used); the
+ * `payload` may be a hex string or byte array
+ * @returns decoded deposit, discriminated by the `type` field, or `undefined`
+ * if `msgSender` is not a portal (i.e. the input is not a deposit); the data
+ * fields follow the representation of the `payload`, and are zero-copy
+ * subarrays when the `payload` is a byte array
+ * @throws if `msgSender` is a portal but the payload is malformed
+ */
+export function decodeDeposit(
+    input: Pick<Input, "msgSender" | "payload">,
+): Deposit | undefined;
+export function decodeDeposit(
+    input: Pick<Input<ByteArray>, "msgSender" | "payload">,
+): Deposit<ByteArray> | undefined;
+export function decodeDeposit(
+    input: Pick<Input<Hex | ByteArray>, "msgSender" | "payload">,
+): Deposit<Hex | ByteArray> | undefined;
+export function decodeDeposit(
+    input: Pick<Input<Hex | ByteArray>, "msgSender" | "payload">,
+): Deposit<Hex | ByteArray> | undefined {
+    const { msgSender, payload } = input;
     if (isAddressEqual(msgSender, etherPortalAddress)) {
         return { type: "EtherDeposit", ...decodeEtherDeposit(payload) };
     }
@@ -640,23 +749,4 @@ const dispatchDeposit = (
         };
     }
     return undefined;
-};
-
-/**
- * Decode the payload of an input as a portal deposit, dispatching on the
- * input's `msgSender`: if it is one of the portal deployment addresses, the
- * payload is decoded with the corresponding decode function.
- * @param input decoded input (only `msgSender` and `payload` are used); the
- * `payload` may be a hex string or byte array
- * @returns decoded deposit, discriminated by the `type` field, or `undefined`
- * if `msgSender` is not a portal (i.e. the input is not a deposit); the data
- * fields follow the representation of the `payload`, and are zero-copy
- * subarrays when the `payload` is a byte array
- * @throws if `msgSender` is a portal but the payload is malformed
- */
-export const decodeDeposit = <data extends Hex | ByteArray>(
-    input: Pick<Input<data>, "msgSender" | "payload">,
-): Deposit<DecodedBytes<data>> | undefined =>
-    dispatchDeposit(input.msgSender, input.payload) as
-        | Deposit<DecodedBytes<data>>
-        | undefined;
+}

--- a/packages/codec/src/types.ts
+++ b/packages/codec/src/types.ts
@@ -1,17 +1,49 @@
-import type { AbiParameter, AbiParameterToPrimitiveType } from "viem";
+import type {
+    AbiParameter,
+    AbiParameterToPrimitiveType,
+    ByteArray,
+    Hex,
+} from "viem";
 
 /**
  * Map named ABI parameters to an object type: `{ name: primitiveType, ... }`.
+ * Dynamic `bytes` parameters are mapped to `bytes` instead of `Hex`, so
+ * decoded objects can carry byte arrays when decoding from byte arrays.
  */
-export type ParamsToObject<params extends readonly AbiParameter[]> = {
+export type ParamsToObject<
+    params extends readonly AbiParameter[],
+    bytes extends Hex | ByteArray = Hex,
+> = {
     [param in params[number] as param extends {
         name: infer name extends string;
     }
         ? name
-        : never]: AbiParameterToPrimitiveType<param>;
+        : never]: param extends { type: "bytes" }
+        ? bytes
+        : AbiParameterToPrimitiveType<param>;
 };
 
 /**
  * Flatten an intersection so hover tooltips show a plain object type.
  */
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+/**
+ * Target representation of encoded data: a `Hex` string (the default) or a
+ * `Uint8Array`.
+ */
+export type To = "hex" | "bytes";
+
+/**
+ * Encoded data in the representation selected by `to`.
+ */
+export type EncodedData<to extends To> = to extends "bytes" ? ByteArray : Hex;
+
+/**
+ * Representation of the variable-size byte fields of a decoded object, given
+ * the representation of the encoded data: hex in, hex out; bytes in, bytes
+ * out.
+ */
+export type DecodedBytes<data extends Hex | ByteArray> = data extends ByteArray
+    ? ByteArray
+    : Hex;

--- a/packages/codec/src/types.ts
+++ b/packages/codec/src/types.ts
@@ -33,17 +33,3 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {};
  * `Uint8Array`.
  */
 export type To = "hex" | "bytes";
-
-/**
- * Encoded data in the representation selected by `to`.
- */
-export type EncodedData<to extends To> = to extends "bytes" ? ByteArray : Hex;
-
-/**
- * Representation of the variable-size byte fields of a decoded object, given
- * the representation of the encoded data: hex in, hex out; bytes in, bytes
- * out.
- */
-export type DecodedBytes<data extends Hex | ByteArray> = data extends ByteArray
-    ? ByteArray
-    : Hex;


### PR DESCRIPTION
Stacked on #135.

Adds `Uint8Array` support to every `@cartesi/codec` function, so low-level bindings (e.g. machine I/O) that already hold binary data can decode without an O(n) hex conversion and 2× memory copy. The package stays isomorphic: only `Uint8Array` (which Node's `Buffer` extends) appears in the API, and hex in → hex out behavior is byte-identical to before.

## Decode

Every decode function (`decodeInput`, `decodeOutput`, `decodeDeposit` and the portal deposit decoders) now also accepts a `Uint8Array`. Variable-size byte fields (`payload`, `execLayerData`, `baseLayerData`) follow the representation of the input — hex in, hex out; bytes in, bytes out — and on the bytes path they are **zero-copy subarrays** of the input. Typing is viem-style generics with the type parameter defaulting to `Hex`, so all existing call sites and type usage compile unchanged.

Since viem's `decodeFunctionData` / `decodeAbiParameters` are hex-only, the bytes path is a small hand-rolled decoder (`src/bytes.ts`) over the fixed `EvmAdvance` / `Outputs` / `InputEncoding` layouts, validated against the same canonical test vectors as the hex path. Selectors are computed from the generated ABIs, and a selector mismatch throws viem's `AbiFunctionSignatureNotFoundError` like the hex path does.

## Encode

Every encode function takes an optional `to` parameter — `"hex"` (the default) or `"bytes"` — selecting the representation of the encoded data, with proper typing via the same generic pattern (`EncodedData<to>`). Byte fields of the objects being encoded are accepted in either representation, so bytes-decoded values re-encode directly. The `"bytes"` path writes into a single preallocated buffer with no hex round-trip.

## Numbers

Decoding an input with a 1 MiB payload: 0.015 ms on the bytes path vs 45 ms via hex conversion (~3000×), with the returned payload sharing the input's buffer.

## Also

- 28 new tests: canonical-vector decode/encode on the bytes path, roundtrips, zero-copy assertions (buffer identity + `byteOffset`), `Buffer` subclass, error parity (short/malformed/unknown-selector, out-of-range uint256)
- docs: all 20 codec pages updated, plus a "Hex strings and byte arrays" section on the codec index (twoslash-checked)
- changeset (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
