### PR TITLE
feat: Add new filter parameter for method cartesi_listInputs

### DIFF
--- a/.changeset/deep-lands-look.md
+++ b/.changeset/deep-lands-look.md
@@ -1,0 +1,8 @@
+---
+"@cartesi/wagmi": patch
+"@cartesi/viem": patch
+"@cartesi/rpc": patch
+"@cartesi/docs": patch
+---
+
+Add new cartesi_listInputs optional query parameter transaction_hash.

--- a/apps/docs/pages/rpc/cartesi_listInputs.mdx
+++ b/apps/docs/pages/rpc/cartesi_listInputs.mdx
@@ -18,9 +18,10 @@ The request can filter results by:
 
 - `epoch_index: HexNumber`
 - `sender: Address`
+- `transaction_hash: Hash`
 
 ```ts twoslash
-import { type Address, type HexNumber } from "@cartesi/rpc"
+import { type Address, type HexNumber, type Hash } from "@cartesi/rpc";
 ```
 
 ## Return Type
@@ -28,10 +29,7 @@ import { type Address, type HexNumber } from "@cartesi/rpc"
 The `data` is an array of `Input`:
 
 ```ts twoslash
-import {
-    type Input,
-    type ListInputsReturnType,
-} from "@cartesi/rpc";
+import { type Input, type ListInputsReturnType } from "@cartesi/rpc";
 ```
 
 For more information about pagination refer to the [pagination section](/rpc#pagination).

--- a/apps/docs/pages/viem/listInputs.mdx
+++ b/apps/docs/pages/viem/listInputs.mdx
@@ -7,14 +7,14 @@ import { http } from "viem";
 import { createCartesiPublicClient } from "@cartesi/viem";
 
 const publicClientL2 = createCartesiPublicClient({
-  transport: http("http://127.0.0.1:6751/rpc"),
+    transport: http("http://127.0.0.1:6751/rpc"),
 });
 
 const { data, pagination } = await publicClientL2.listInputs({
-  application: "0x...",
-  limit: 10,
-  offset: 0,
-  // epochIndex, sender (optional)
+    application: "0x...",
+    limit: 10,
+    offset: 0,
+    // epochIndex, sender (optional)
 });
 ```
 
@@ -26,6 +26,7 @@ import type { ListInputsParams } from "@cartesi/viem";
 //   application: Address | string;
 //   epochIndex?: bigint;
 //   sender?: Address;
+//   transactionHash?: Hash;
 //   limit?: number;
 //   offset?: number;
 //   descending?: boolean;

--- a/apps/docs/pages/wagmi/useInputs.mdx
+++ b/apps/docs/pages/wagmi/useInputs.mdx
@@ -6,14 +6,14 @@
 import { useInputs } from "@cartesi/wagmi";
 
 function Example() {
-  const { data, isLoading } = useInputs({
-    application: "0x...",
-    limit: 50,
-    offset: 0,
-    // ...other filters
-  });
-  const { data: inputs, pagination } = data || {};
-  // render logic
+    const { data, isLoading } = useInputs({
+        application: "0x...",
+        limit: 50,
+        offset: 0,
+        // ...other filters
+    });
+    const { data: inputs, pagination } = data || {};
+    // render logic
 }
 ```
 
@@ -24,23 +24,18 @@ The hook can filter results by:
 - `application: Address | string`
 - `epochIndex?: bigint`
 - `sender?: Address`
+- `transactionHash?: Hash`
 
 ```ts twoslash
-import type {
-  ListInputsParams,
-} from "@cartesi/viem";
+import type { ListInputsParams } from "@cartesi/viem";
 ```
 
 ## Return Type
 
 The `data` is an array of `Input`:
 
-```ts twoslash 
-import type {
-  Input,
-  ListInputsReturnType,
-  Pagination,
-} from "@cartesi/viem";
+```ts twoslash
+import type { Input, ListInputsReturnType, Pagination } from "@cartesi/viem";
 ```
 
 For more information about pagination refer to the [pagination section](/wagmi#index).

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -402,6 +402,7 @@ export type ListInputsParams = PaginationParams & {
     application: string | Address;
     epoch_index?: HexNumber;
     sender?: Address;
+    transaction_hash?: Hash;
 };
 
 export type ListInputsReturnType = PaginatedReturnType<Input>;

--- a/packages/viem/src/actions/listInputs.ts
+++ b/packages/viem/src/actions/listInputs.ts
@@ -10,14 +10,26 @@ export const listInputs = async (
     client: Client<Transport, undefined, undefined, PublicCartesiRpcSchema>,
     params: ListInputsParams,
 ): Promise<ListInputsReturnType> => {
+    const {
+        application,
+        descending,
+        epochIndex,
+        transactionHash: transaction_hash,
+        limit,
+        offset,
+        sender,
+    } = params;
     const inputs = await client.request({
         method: "cartesi_listInputs",
         params: {
-            ...params,
+            application,
+            descending,
+            limit,
+            offset,
+            sender,
+            transaction_hash,
             epoch_index:
-                params.epochIndex !== undefined
-                    ? numberToHex(params.epochIndex)
-                    : undefined,
+                epochIndex !== undefined ? numberToHex(epochIndex) : undefined,
         },
     });
     return {

--- a/packages/viem/src/types/actions.ts
+++ b/packages/viem/src/types/actions.ts
@@ -385,6 +385,7 @@ export type ListInputsParams = PaginationParams & {
     application: Address | string;
     epochIndex?: bigint;
     sender?: Address;
+    transactionHash?: Hash;
 };
 
 export type ListInputsReturnType = {


### PR DESCRIPTION
## Summary
Code change to support the rollups-node JSON-RPC API addition coming in the next `alpha.13`. A new optional filter parameter `transaction_hash` was introduced for the method `cartesi_listInputs`. 

Ref: https://github.com/cartesi/rollups-node/compare/v2.0.0-alpha.12...next/2.0#diff-b27a1226c89c683ea43d93d2cda5214076da3076216fcf70850a6200b9254672R268  **The reviewer may need to hit enter twice in the address bar as github does not work very well in that view mode when targetting specific diff line.**