### PR TITLE
fix: align @cartesi/rpc and @cartesi/viem types with the node OpenRPC schema

### DIFF
--- a/.changeset/gold-spies-check.md
+++ b/.changeset/gold-spies-check.md
@@ -1,0 +1,6 @@
+---
+"@cartesi/rpc": minor
+"@cartesi/viem": minor
+---
+
+align types with the node's OpenRPC schema: rename `Input.transaction_reference` to `transaction_hash`, add `Input.log_index`, add `Report.epochIndex` to the viem `Report` type, make `Commitment.submitterAddress` non-nullable, and tighten `chain_id`, `prev_randao` and `cartesi_getChainId` result types to hex-encoded values

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -167,19 +167,20 @@ export type Input = {
     block_number: HexNumber;
     raw_data: Hex;
     decoded_data: {
-        chain_id: string;
+        chain_id: HexNumber;
         application_contract: Address;
         sender: Address;
         block_number: HexNumber;
         block_timestamp: HexNumber;
-        prev_randao: string;
+        prev_randao: Hex;
         index: HexNumber;
         payload: Hex;
     } | null;
     status: InputStatus;
     machine_hash: Hash | null;
     outputs_hash: Hash | null;
-    transaction_reference: Hex;
+    transaction_hash: Hash;
+    log_index: HexNumber;
     created_at: DateTime;
     updated_at: DateTime;
 };
@@ -426,7 +427,7 @@ export type ListReportsParams = PaginationParams & {
 export type ListReportsReturnType = PaginatedReturnType<Report>;
 
 export type GetChainIdReturnType = {
-    data: string;
+    data: HexNumber;
 };
 
 export type GetNodeVersionReturnType = {

--- a/packages/viem/__tests__/converter.test.ts
+++ b/packages/viem/__tests__/converter.test.ts
@@ -1,10 +1,19 @@
-import type { Application, Epoch, Output, Withdrawal } from "@cartesi/rpc";
+import type {
+    Application,
+    Epoch,
+    Input,
+    Output,
+    Report,
+    Withdrawal,
+} from "@cartesi/rpc";
 import { getAddress, hexToBigInt } from "viem";
 import { describe, expect, it } from "vitest";
 import {
     applicationConverter,
     epochConverter,
+    inputConverter,
     outputConverter,
+    reportConverter,
     withdrawalConverter,
 } from "../src/types/converter.js";
 
@@ -459,6 +468,81 @@ describe("converter", () => {
         expect(output.decodedData?.payload).toBe(
             rpcOutput.decoded_data?.payload,
         );
+    });
+
+    it("should convert the input", () => {
+        const rpcInput: Input = {
+            epoch_index: "0x1",
+            index: "0x7",
+            block_number: "0x1f4",
+            raw_data: "0x415bf363",
+            decoded_data: {
+                chain_id: "0x7a69",
+                application_contract:
+                    "0x8b2c3a19e91d0f8e2ca48c7ba0c2ee52a6b7d94f",
+                sender: "0xabcdef1234567890abcdef1234567890abcdef12",
+                block_number: "0x1f4",
+                block_timestamp: "0x67f8e5c0",
+                prev_randao:
+                    "0x2e17ac5d9b043f86d1c74a9e2f50b8d3c6a91e04f7b52d8ca31e6f90b4d27a58",
+                index: "0x7",
+                payload: "0xdeadbeef",
+            },
+            status: "ACCEPTED",
+            machine_hash: null,
+            outputs_hash: null,
+            transaction_hash:
+                "0x8f2c9ab4d7e15c30b6f18a4ee2d9037c4a1f5d2e9b7c63a0d4e8f1b25c7a9d3e",
+            log_index: "0x2",
+            created_at: "2025-04-11T10:00:00.000Z",
+            updated_at: "2025-04-11T10:05:00.000Z",
+        };
+
+        const input = inputConverter(rpcInput);
+        expect(input.epochIndex).toBe(hexToBigInt(rpcInput.epoch_index));
+        expect(input.index).toBe(hexToBigInt(rpcInput.index));
+        expect(input.blockNumber).toBe(hexToBigInt(rpcInput.block_number));
+        expect(input.rawData).toBe(rpcInput.raw_data);
+        expect(input.status).toBe(rpcInput.status);
+        expect(input.machineHash).toBeNull();
+        expect(input.outputsHash).toBeNull();
+        expect(input.transactionHash).toBe(rpcInput.transaction_hash);
+        expect(input.logIndex).toBe(hexToBigInt(rpcInput.log_index));
+        expect(input.decodedData).toBeDefined();
+        expect(input.decodedData?.chainId).toBe(
+            hexToBigInt(rpcInput.decoded_data?.chain_id ?? "0x0"),
+        );
+        expect(input.decodedData?.applicationContract).toBe(
+            getAddress(rpcInput.decoded_data?.application_contract ?? "0x"),
+        );
+        expect(input.decodedData?.sender).toBe(
+            getAddress(rpcInput.decoded_data?.sender ?? "0x"),
+        );
+        expect(input.decodedData?.prevRandao).toBe(
+            hexToBigInt(rpcInput.decoded_data?.prev_randao ?? "0x0"),
+        );
+        expect(input.decodedData?.payload).toBe(rpcInput.decoded_data?.payload);
+        expect(input.createdAt).toStrictEqual(new Date(rpcInput.created_at));
+        expect(input.updatedAt).toStrictEqual(new Date(rpcInput.updated_at));
+    });
+
+    it("should convert the report", () => {
+        const rpcReport: Report = {
+            epoch_index: "0x1",
+            input_index: "0x7",
+            index: "0x0",
+            raw_data: "0x4e756d626572206f6620616476616e6365733a2031",
+            created_at: "2025-04-11T10:00:00.000Z",
+            updated_at: "2025-04-11T10:05:00.000Z",
+        };
+
+        const report = reportConverter(rpcReport);
+        expect(report.epochIndex).toBe(hexToBigInt(rpcReport.epoch_index));
+        expect(report.inputIndex).toBe(hexToBigInt(rpcReport.input_index));
+        expect(report.index).toBe(hexToBigInt(rpcReport.index));
+        expect(report.rawData).toBe(rpcReport.raw_data);
+        expect(report.createdAt).toStrictEqual(new Date(rpcReport.created_at));
+        expect(report.updatedAt).toStrictEqual(new Date(rpcReport.updated_at));
     });
 
     it("should convert the withdrawal", () => {

--- a/packages/viem/src/actions/getChainId.ts
+++ b/packages/viem/src/actions/getChainId.ts
@@ -1,4 +1,4 @@
-import type { Client, Hex, Transport } from "viem";
+import type { Client, Transport } from "viem";
 import { hexToNumber } from "viem";
 import type { PublicCartesiRpcSchema } from "../decorators/publicL2.js";
 import type { GetChainIdReturnType } from "../types/actions.js";
@@ -10,5 +10,5 @@ export const getChainId = async (
         method: "cartesi_getChainId",
         params: [],
     });
-    return hexToNumber(chainId as Hex);
+    return hexToNumber(chainId);
 };

--- a/packages/viem/src/types/actions.ts
+++ b/packages/viem/src/types/actions.ts
@@ -166,7 +166,7 @@ export type Commitment = {
     tournamentAddress: Address;
     commitment: Hash;
     finalStateHash: Hash;
-    submitterAddress: Address | null;
+    submitterAddress: Address;
     blockNumber: bigint;
     txHash: Hash;
     createdAt: Date;
@@ -253,7 +253,8 @@ export type Input = {
     status: InputStatus;
     machineHash: Hash | null;
     outputsHash: Hash | null;
-    transactionReference: Hash;
+    transactionHash: Hash;
+    logIndex: bigint;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -310,6 +311,7 @@ export type GetReportParams = {
 };
 
 export type Report = {
+    epochIndex: bigint;
     inputIndex: bigint;
     index: bigint;
     rawData: Hex;

--- a/packages/viem/src/types/converter.ts
+++ b/packages/viem/src/types/converter.ts
@@ -220,9 +220,7 @@ export const commitmentConverter = (commitment: CommitmentRpc): Commitment => {
         tournamentAddress: getAddress(commitment.tournament_address),
         commitment: commitment.commitment,
         finalStateHash: commitment.final_state_hash,
-        submitterAddress: commitment.submitter_address
-            ? getAddress(commitment.submitter_address)
-            : null,
+        submitterAddress: getAddress(commitment.submitter_address),
         blockNumber: hexToBigInt(commitment.block_number),
         txHash: commitment.tx_hash,
         createdAt: new Date(commitment.created_at),
@@ -275,7 +273,7 @@ export const inputConverter = (input: InputRpc): Input => {
         rawData: input.raw_data,
         decodedData: input.decoded_data
             ? {
-                  chainId: hexToBigInt(input.decoded_data.chain_id as Hex),
+                  chainId: hexToBigInt(input.decoded_data.chain_id),
                   applicationContract: getAddress(
                       input.decoded_data.application_contract,
                   ),
@@ -284,9 +282,7 @@ export const inputConverter = (input: InputRpc): Input => {
                   blockTimestamp: hexToBigInt(
                       input.decoded_data.block_timestamp,
                   ),
-                  prevRandao: hexToBigInt(
-                      input.decoded_data.prev_randao as Hex,
-                  ),
+                  prevRandao: hexToBigInt(input.decoded_data.prev_randao),
                   index: hexToBigInt(input.decoded_data.index),
                   payload: input.decoded_data.payload,
               }
@@ -294,7 +290,8 @@ export const inputConverter = (input: InputRpc): Input => {
         status: input.status,
         machineHash: input.machine_hash,
         outputsHash: input.outputs_hash,
-        transactionReference: input.transaction_reference,
+        transactionHash: input.transaction_hash,
+        logIndex: hexToBigInt(input.log_index),
         createdAt: new Date(input.created_at),
         updatedAt: new Date(input.updated_at),
     };
@@ -347,6 +344,7 @@ export const outputConverter = (output: OutputRpc): Output => {
 
 export const reportConverter = (report: ReportRpc): Report => {
     return {
+        epochIndex: hexToBigInt(report.epoch_index),
         inputIndex: hexToBigInt(report.input_index),
         index: hexToBigInt(report.index),
         rawData: report.raw_data,


### PR DESCRIPTION
Fixes discrepancies found while validating `@cartesi/rpc` against the node's OpenRPC discovery document (`rpc-discover`, API version 2.0.0).

> Originally stacked on #143; now rebased onto `prerelease/v2-alpha` after #143 merged.

## Changes

### `@cartesi/rpc`
- **`Input.transaction_reference` → `Input.transaction_hash`** — the spec's `Input` schema has `transaction_hash` (32-byte `Hash` of the L1 tx that emitted `InputAdded`); `transaction_reference` no longer exists.
- **Add `Input.log_index`** — present in the spec's `Input` schema but missing from the type (`Withdrawal` already had it).
- Tighten loosely-typed hex fields to match the spec formats: `EvmAdvance.chain_id` (`string` → `HexNumber`), `EvmAdvance.prev_randao` (`string` → `Hex`), and `GetChainIdReturnType.data` (`string` → `HexNumber`).

### `@cartesi/viem`
- `Input` type: `transactionReference` → `transactionHash`, new `logIndex: bigint`; `inputConverter` updated accordingly.
- `Report` type/converter: add the missing `epochIndex` (the rpc wire type already carried `epoch_index`, but the converter dropped it).
- `Commitment.submitterAddress`: now non-nullable `Address` — the spec never returns null, and the converter's null guard was dead code.
- Removed the `as Hex` casts in `inputConverter` and `getChainId` that papered over the loose rpc types.
- New converter tests for `inputConverter` and `reportConverter`.

A changeset (minor for both packages) is included.

## Not addressed (needs confirmation)
The spec types decoded output `type` (`Notice`/`Voucher`/`DelegateCallVoucher`) as a `FunctionSelector` (`^0x[a-fA-F0-9]{8}$`), while the code uses the literal strings `"Notice" | "Voucher" | "DelegateCallVoucher"`. If the node really serializes 4-byte selectors, `parseOutputDecodedData` would never match — but this needs checking against actual node output before changing, since the spec may be the inaccurate side. Left as-is for now.

## Verification
- `pnpm build` — all 5 packages build (including viem/wagmi codegen)
- `pnpm lint` — clean
- `vitest run` in `@cartesi/viem` — 6/6 tests pass
- `tsc --noEmit` in `packages/viem` — clean (pre-existing, unrelated errors in `packages/rpc/src/index.ts` exist on the base branch too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCPKdLAnAh2QPAonMecezS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCPKdLAnAh2QPAonMecezS)_