### PR TITLE
Simplify useChainId and useNodeVersion to accept no param

### DIFF
--- a/.changeset/quiet-hooks-relax.md
+++ b/.changeset/quiet-hooks-relax.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/react": patch
+---
+
+Make the `params` argument optional for `useChainId` and `useNodeVersion`, so they can be called with no argument (`useChainId()` instead of `useChainId({})`). Both hooks only accept the optional query-options object, so the empty object was never required. The change is backward compatible.

--- a/packages/react/src/publicL2/useChainId.ts
+++ b/packages/react/src/publicL2/useChainId.ts
@@ -16,7 +16,7 @@ export const chainIdOptions = (client: CartesiPublicClient) =>
     });
 
 export const useChainId = (
-    params: Omit<ReturnType<typeof chainIdOptions>, "queryKey" | "queryFn">,
+    params?: Omit<ReturnType<typeof chainIdOptions>, "queryKey" | "queryFn">,
 ) => {
     const client = useCartesiClient();
     return useQuery({

--- a/packages/react/src/publicL2/useNodeVersion.ts
+++ b/packages/react/src/publicL2/useNodeVersion.ts
@@ -16,7 +16,10 @@ export const nodeVersionOptions = (client: CartesiPublicClient) =>
     });
 
 export const useNodeVersion = (
-    params: Omit<ReturnType<typeof nodeVersionOptions>, "queryKey" | "queryFn">,
+    params?: Omit<
+        ReturnType<typeof nodeVersionOptions>,
+        "queryKey" | "queryFn"
+    >,
 ) => {
     const client = useCartesiClient();
     return useQuery({


### PR DESCRIPTION
## Summary

Makes the `params` argument optional for the two React hooks that take no data-specific arguments, so they can be called with no argument at all:

- `useChainId()` instead of `useChainId({})`
- `useNodeVersion()` instead of `useNodeVersion({})`

Both hooks' only param is the (already fully-optional) TanStack Query options object, yet the param itself was required — forcing callers to pass an empty `{}`. This brings them in line with `useApplications`, which already treats a no-required-data endpoint as an optional param.

## Scope

Only `useChainId` and `useNodeVersion` are changed. The data and list hooks (`useInput`, `useOutputs`, `useApplication`, etc.) are intentionally left as-is: they require an `application` (or other identifiers) to run and merely `skipToken` when those are absent, so a required object still fits their usage.

The change is backward compatible — existing `useChainId({})` / `useNodeVersion({})` calls still typecheck. The hook bodies already spread `...params`, and `{...undefined}` is a valid no-op, so no logic changes were needed.

## Notes

- Formatting applied via Biome.
- A full type-check/build could not be run in this environment because the codegen step downloads the rollups-contracts tarballs via Node's global `fetch`, which does not route through the sandbox proxy. This is unrelated to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DixvsDxdNuuzo2TaAiBUe3)_