### PR TITLE
feat: Add new JSONRPC API changes

### DIFF
--- a/.changeset/small-knives-sing.md
+++ b/.changeset/small-knives-sing.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rpc": patch
+---
+
+**`cartesi_listEpochs`**: Updated `status` param to accept either a single `EpochStatus` or a non-empty array (`minItems: 1`). Added optional `from` and `to` inclusive range parameters (`HexNumber`).

--- a/packages/rpc/src/types.ts
+++ b/packages/rpc/src/types.ts
@@ -16,6 +16,8 @@ export type Pagination = {
     offset: number;
 };
 
+type NonEmptyArray<T> = [T, ...T[]];
+
 type PaginatedReturnType<T> = {
     data: T[];
     pagination: Pagination;
@@ -259,7 +261,9 @@ export type ListApplicationsReturnType = PaginatedReturnType<Application>;
 
 export type ListEpochsParams = PaginationParams & {
     application: string | Address;
-    status?: EpochStatus;
+    status?: EpochStatus | NonEmptyArray<EpochStatus>;
+    from?: HexNumber;
+    to?: HexNumber;
 };
 
 export type ListEpochsReturnType = PaginatedReturnType<Epoch>;


### PR DESCRIPTION
## Summary
Code changes to include changes in the current and upcoming rollups-node JSONRPC API. 


Tracking rollups-node PRs:
- https://github.com/cartesi/rollups-node/pull/793