### PR TITLE
Update package installation docs to use @alpha npm tag

### DIFF
--- a/apps/docs/pages/codec/index.mdx
+++ b/apps/docs/pages/codec/index.mdx
@@ -14,17 +14,21 @@ The package decodes those blobs into friendly typed objects, and encodes typed o
 :::code-group
 
 ```sh [npm]
-npm install @cartesi/codec viem
+npm install @cartesi/codec@alpha viem
 ```
 
 ```sh [pnpm]
-pnpm add @cartesi/codec viem
+pnpm add @cartesi/codec@alpha viem
 ```
 
 ```sh [yarn]
-yarn add @cartesi/codec viem
+yarn add @cartesi/codec@alpha viem
 ```
 
+:::
+
+:::warning
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 ## Hex strings and byte arrays

--- a/apps/docs/pages/machine/index.mdx
+++ b/apps/docs/pages/machine/index.mdx
@@ -17,16 +17,20 @@ It provides a fully typed and ergonomic TypeScript API for the Cartesi Machine C
 :::code-group
 
 ```bash [pnpm]
-pnpm add @cartesi/machine
+pnpm add @cartesi/machine@alpha
 ```
 
 ```bash [npm]
-npm install @cartesi/machine
+npm install @cartesi/machine@alpha
 ```
 
 ```bash [yarn]
-yarn add @cartesi/machine
+yarn add @cartesi/machine@alpha
 ```
+:::
+
+:::warning
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 On Linux (x64, arm64) and macOS (x64, arm64) this installs a prebuilt platform package (`@cartesi/machine-<platform>-<arch>`) containing the native addon and the JSON-RPC server executable — no compiler needed.

--- a/apps/docs/pages/react/index.mdx
+++ b/apps/docs/pages/react/index.mdx
@@ -9,17 +9,21 @@ Add the library to your existing React project.
 :::code-group
  
 ```bash [pnpm]
-pnpm add @tanstack/react-query @cartesi/react
+pnpm add @tanstack/react-query @cartesi/react@alpha
 ```
  
 ```bash [npm]
-npm install @tanstack/react-query @cartesi/react
+npm install @tanstack/react-query @cartesi/react@alpha
 ```
  
 ```bash [yarn]
-yarn add @tanstack/react-query @cartesi/react
+yarn add @tanstack/react-query @cartesi/react@alpha
 ```
 
+:::
+
+:::warning
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 ## Setup

--- a/apps/docs/pages/rollup/getting-started.mdx
+++ b/apps/docs/pages/rollup/getting-started.mdx
@@ -5,17 +5,21 @@
 :::code-group
 
 ```sh [npm]
-npm install @cartesi/rollup
+npm install @cartesi/rollup@alpha
 ```
 
 ```sh [pnpm]
-pnpm add @cartesi/rollup
+pnpm add @cartesi/rollup@alpha
 ```
 
 ```sh [yarn]
-yarn add @cartesi/rollup
+yarn add @cartesi/rollup@alpha
 ```
 
+:::
+
+:::warning
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 Prebuilt binaries are used automatically on linux-x64, linux-arm64, linux-riscv64, darwin-x64 and darwin-arm64 — no toolchain needed. The package is dual ESM + CommonJS and ships TypeScript types.

--- a/apps/docs/pages/rollup/index.mdx
+++ b/apps/docs/pages/rollup/index.mdx
@@ -34,17 +34,21 @@ This is the guest side of the rollups protocol: the blobs this package emits and
 :::code-group
 
 ```sh [npm]
-npm install @cartesi/rollup
+npm install @cartesi/rollup@alpha
 ```
 
 ```sh [pnpm]
-pnpm add @cartesi/rollup
+pnpm add @cartesi/rollup@alpha
 ```
 
 ```sh [yarn]
-yarn add @cartesi/rollup
+yarn add @cartesi/rollup@alpha
 ```
 
+:::
+
+:::warning
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 ## Where to go next

--- a/apps/docs/pages/wagmi-plugin/index.mdx
+++ b/apps/docs/pages/wagmi-plugin/index.mdx
@@ -11,17 +11,21 @@ Add the plugin and the Wagmi CLI as development dependencies of your project.
 :::code-group
 
 ```bash [pnpm]
-pnpm add -D @cartesi/wagmi-plugin @wagmi/cli
+pnpm add -D @cartesi/wagmi-plugin@alpha @wagmi/cli
 ```
 
 ```bash [npm]
-npm install --save-dev @cartesi/wagmi-plugin @wagmi/cli
+npm install --save-dev @cartesi/wagmi-plugin@alpha @wagmi/cli
 ```
 
 ```bash [yarn]
-yarn add -D @cartesi/wagmi-plugin @wagmi/cli
+yarn add -D @cartesi/wagmi-plugin@alpha @wagmi/cli
 ```
 
+:::
+
+:::warning
+While in pre-release, the plugin is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 :::
 
 ## Usage

--- a/packages/codec/README.md
+++ b/packages/codec/README.md
@@ -7,8 +7,10 @@ Inputs delivered to a Cartesi application and outputs produced by it are ABI-enc
 ## Installation
 
 ```sh
-npm install @cartesi/codec viem
+npm install @cartesi/codec@alpha viem
 ```
+
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 
 ## Usage
 

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -14,8 +14,10 @@ The API is **fully synchronous** on purpose: calls that wait on the emulator (`f
 ## Installation
 
 ```sh
-npm install @cartesi/rollup
+npm install @cartesi/rollup@alpha
 ```
+
+While in pre-release, the library is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 
 Prebuilt addons are published for linux-x64, linux-arm64, linux-riscv64, darwin-x64 and darwin-arm64. On any other platform the addon is compiled from the libcmt sources shipped in the tarball, which requires a C/C++ toolchain and Python (node-gyp).
 

--- a/packages/wagmi-plugin/README.md
+++ b/packages/wagmi-plugin/README.md
@@ -5,8 +5,10 @@ A [wagmi CLI](https://wagmi.sh/cli/getting-started) plugin that generates code f
 ## Installation
 
 ```bash
-pnpm add -D @cartesi/wagmi-plugin @wagmi/cli
+pnpm add -D @cartesi/wagmi-plugin@alpha @wagmi/cli
 ```
+
+While in pre-release, the plugin is published under the `alpha` npm tag. The `@alpha` suffix is required: without it npm resolves the `latest` tag, which does not point to the version documented here.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Updated installation instructions across all documentation and package README files to specify the `@alpha` npm tag for pre-release packages. Added warning notices explaining why the `@alpha` suffix is required during the pre-release phase.

## Key Changes
- Updated npm/pnpm/yarn installation commands in documentation to include `@alpha` tag for:
  - `@cartesi/codec`
  - `@cartesi/machine`
  - `@cartesi/react`
  - `@cartesi/rollup`
  - `@cartesi/wagmi-plugin`
- Added standardized warning blocks in all documentation pages explaining that the `@alpha` suffix is required to resolve the correct pre-release version (without it, npm resolves to the `latest` tag which points to a different version)
- Updated package README files (`codec`, `rollup`, `wagmi-plugin`) with the same installation guidance and warning text

## Implementation Details
- The warning message is consistent across all documentation files, clearly explaining the pre-release publishing strategy
- Installation instructions now match the actual npm registry state where these packages are published under the `alpha` tag
- Changes ensure users installing from documentation will get the correct pre-release versions

https://claude.ai/code/session_01BRCc9jAg5jM9Aa7fKqte6s