### PR TITLE
fix(rollup): resolve run() when the host mock runs out of inputs

### DIFF
--- a/.changeset/olive-otters-return.md
+++ b/.changeset/olive-otters-return.md
@@ -1,0 +1,14 @@
+---
+"@cartesi/rollup": major
+"@cartesi/docs": patch
+---
+
+`Rollup.run` now resolves when the host mock runs out of inputs, instead of rejecting.
+
+The `finish` call sat outside the loop's `try`, so the failure libcmt's mock IO driver raises when the `CMT_INPUTS` list is exhausted — the normal end of a host test run — escaped as an unhandled rejection, and every successful run exited non-zero. `run` now catches it and returns.
+
+The mock reports exhaustion with two different errnos for the same condition, depending on how the last request ended: `-ENODATA` after an accepted one, `-ENOSYS` after a rejected one (`io-mock.c`, `mock_rx_accepted` vs `mock_rx_rejected`). Both are recognized, so applications that reject their last input also exit cleanly. The errno values are read from `node:os` rather than hardcoded, since they differ between Linux and macOS.
+
+Because `-ENOSYS` ("function not implemented") is a plausible genuine failure from a real device, it is only treated as an end of run when the addon was built against the mock driver. To make that check honest, the native addon now reports which libcmt IO driver it was compiled against, and the package exports it as `driver` (`"ioctl"` inside a Cartesi Machine, `"mock"` on a development host), typed `RollupDriver`. The driver is selected by `binding.gyp` from the target architecture at build time, so this is more reliable than sniffing `CMT_INPUTS`, and it makes the `-ENOSYS` special case provably unreachable in a real machine. Any other `finish` failure — including `-ENODATA` from a real device, where the loop is meant to run forever — still rejects.
+
+**Breaking (types):** `run` returns `Promise<void>` instead of `Promise<never>`. Code that relied on `never` (for control-flow narrowing after `await rollup.run(...)`, or assigning the result to a `never`-typed position) no longer type-checks. Host tests that wrapped the loop in a `.catch(() => {})` to swallow the exhaustion error can drop it — they now hide real errors instead.

--- a/apps/docs/pages/rollup/finish.mdx
+++ b/apps/docs/pages/rollup/finish.mdx
@@ -67,7 +67,9 @@ The call is **synchronous and blocking on purpose**: yielding pauses the entire 
 
 ## Errors
 
-| Condition                | Error                                                 |
-| ------------------------ | ----------------------------------------------------- |
-| No more inputs (mock)    | `RollupError` with the negative errno in `errno`      |
-| Device closed            | `Error` (`close()` was called)                        |
+| Condition                | Error                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| No more inputs (mock)    | `RollupError` with `-ENODATA` after an accepted request, `-ENOSYS` after a rejected one  |
+| Device closed            | `Error` (`close()` was called)                                                           |
+
+Both errnos mean the same thing — the [`CMT_INPUTS`](/rollup/testing) list is exhausted — and [`run`](/rollup/run) treats either as the end of a host session.

--- a/apps/docs/pages/rollup/handling-requests.mdx
+++ b/apps/docs/pages/rollup/handling-requests.mdx
@@ -148,4 +148,6 @@ The request is a discriminated union — narrowing on `type` gives you the right
 
 ## When the loop ends
 
-`run` returns a `Promise<never>`: under normal operation inside the machine, the loop never ends. It rejects when `finish` fails — for example when the mock runs out of inputs during [host testing](/rollup/testing), or after [`close`](/rollup/close) is called. Let the rejection propagate (the process exits), or catch it if you have cleanup to do.
+`run` returns a `Promise<void>`, but under normal operation inside the machine the loop never ends — the promise simply never settles. It **rejects** when `finish` fails for a real reason, such as after [`close`](/rollup/close) is called: let that propagate (the process exits) or catch it if you have cleanup to do.
+
+It **resolves** in exactly one case: the host mock ran out of the inputs listed in `CMT_INPUTS`, the normal end of a [test session](/rollup/testing). That is decided by the driver the binding was built against, not by the environment, so inside a real machine an exhaustion-looking errno is still an error.

--- a/apps/docs/pages/rollup/run.mdx
+++ b/apps/docs/pages/rollup/run.mdx
@@ -22,7 +22,12 @@ await rollup.run({
 
 ## Returns
 
-`Promise<never>` — the loop runs until `finish` fails (inputs exhausted on the mock, or device closed), and the promise rejects with that error. It never resolves.
+`Promise<void>`, and where it settles depends on which side you are running:
+
+- **Inside a Cartesi Machine** the loop never ends on its own — the application is meant to keep serving requests forever. The promise only settles if `finish` fails (for example the device was [closed](/rollup/close)), and then it **rejects** with that error.
+- **On the host mock** it also **resolves** once the inputs listed in `CMT_INPUTS` run out, which is the natural end of a [test session](/rollup/testing). Any other `finish` failure still rejects.
+
+So a host test can simply `await rollup.run(...)` and then assert on the outputs, with no `catch` in the way.
 
 ## Parameters
 

--- a/apps/docs/pages/rollup/testing.mdx
+++ b/apps/docs/pages/rollup/testing.mdx
@@ -20,7 +20,21 @@ The _reason_ selects the request type:
 
 Set `CMT_DEBUG=yes` to make the mock log every operation.
 
-When the input list is exhausted, the next [`finish`](/rollup/finish) call fails and [`run`](/rollup/run) rejects — that is your test's natural end-of-session signal.
+When the input list is exhausted, the next [`finish`](/rollup/finish) call fails — that is your test's natural end-of-session signal. [`run`](/rollup/run) recognizes it and **resolves**, so a test can `await` the loop and then assert on the outputs. Driving `finish` yourself, you see the failure directly as a `RollupError`, whose `errno` depends on how the last request ended: `-ENODATA` if it was accepted, `-ENOSYS` if it was rejected (the mock's two ways of saying the same thing). Rejecting a request that is _not_ the last one just moves on to the next input.
+
+```ts twoslash
+import { constants } from "node:os";
+import { RollupError, driver } from "@cartesi/rollup";
+
+const exhausted = (error: unknown) =>
+    driver === "mock" &&
+    error instanceof RollupError &&
+    error.syscall === "cmt_rollup_finish" &&
+    (error.errno === -constants.errno.ENODATA ||
+        error.errno === -constants.errno.ENOSYS);
+```
+
+`driver` tells you which half of libcmt the binding was built against — `"mock"` on your host, `"ioctl"` inside a Cartesi Machine. It is fixed at build time by the target architecture, so it is a reliable check, unlike looking at `CMT_INPUTS`.
 
 ## Collecting outputs
 
@@ -97,17 +111,15 @@ test("echoes the payload as a notice", async () => {
     process.env.CMT_INPUTS = `0:${input}`;
 
     // the app under test: import it AFTER setting CMT_INPUTS, since the
-    // device opens on construction. run() rejects when inputs run out.
+    // device opens on construction. run() resolves when inputs run out.
     const { Rollup } = await import("@cartesi/rollup");
     const rollup = new Rollup();
-    await rollup
-        .run({
-            advance(request, rollup) {
-                rollup.emitNotice(request.payload);
-                return true;
-            },
-        })
-        .catch(() => {}); // inputs exhausted — session over
+    await rollup.run({
+        advance(request, rollup) {
+            rollup.emitNotice(request.payload);
+            return true;
+        },
+    }); // resolves once the inputs are exhausted — session over
 
     const output = decodeOutput(
         fs.readFileSync(path.join(dir, "input.output-0.bin")),

--- a/apps/docs/pages/rollup/types.mdx
+++ b/apps/docs/pages/rollup/types.mdx
@@ -11,6 +11,7 @@ import type {
     GioResponse,
     Hex,
     InspectRequest,
+    RollupDriver,
     RollupRequest,
     RunHandlers,
     U256Like,
@@ -83,6 +84,15 @@ ADDRESS_LENGTH;
 // ^?
 
 U256_LENGTH;
+// ^?
+```
+
+`driver` (typed `RollupDriver`) reports which libcmt IO driver the native addon was built against — `"ioctl"` for the real Cartesi Machine kernel driver on riscv64, `"mock"` for the file-based [host simulation](/rollup/testing). The choice is made at build time from the target architecture, so it is the honest answer to "am I running inside a machine?", where `CMT_INPUTS` being set is only a hint:
+
+```ts twoslash
+import { driver } from "@cartesi/rollup";
+
+driver;
 // ^?
 ```
 

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -77,6 +77,8 @@ The JavaScript half of the binding is written in TypeScript (`src/*.ts`) and bun
 | `close()`                                          | Releases the device.                                                                                                 |
 | `run({ advance, inspect })`                        | Convenience loop over `finish`; handlers may be async. Handler exceptions reject the input and are emitted as reports. |
 
+The package also exports `driver`, the libcmt IO driver the addon was built against: `"ioctl"` inside the machine, `"mock"` on the host. It is decided at build time by the target architecture, so it is a reliable "am I running for real?" check.
+
 Failed libcmt calls throw a `RollupError` with the negative errno in `error.errno` and the failed call in `error.syscall`.
 
 The blobs this package emits and receives are the same ones [`@cartesi/codec`](../codec) encodes and decodes off-chain.
@@ -90,7 +92,9 @@ CMT_INPUTS="0:advance.bin,1:inspect.bin" node my-app.js
 # -> advance.output-0.bin, advance.report-0.bin, ...
 ```
 
-Reason `0` is advance (EVM-ABI encoded `EvmAdvance`), `1` is inspect (raw payload); any other reason is a gio reply with that response code. Set `CMT_DEBUG=yes` for verbose logging. See the [libcmt README](https://github.com/cartesi/machine-guest-tools/tree/main/sys-utils/libcmt#testing) for how to generate inputs with foundry's `cast`, or `__tests__/rollup.test.ts` here for a pure-JS encoder.
+Reason `0` is advance (EVM-ABI encoded `EvmAdvance`), `1` is inspect (raw payload); any other reason is a gio reply with that response code. Set `CMT_DEBUG=yes` for verbose logging.
+
+When the inputs run out, the next `finish` fails — that is the end of a host session, so `run()` resolves there and the process exits normally. The mock reports it as `-ENODATA` if the last request was accepted and `-ENOSYS` if it was rejected; both are recognized, and only when the addon was built against the mock, so an `-ENOSYS` coming from a real device is never mistaken for an end of run. Driving `finish` yourself, you get the `RollupError` and decide. See the [libcmt README](https://github.com/cartesi/machine-guest-tools/tree/main/sys-utils/libcmt#testing) for how to generate inputs with foundry's `cast`, or `__tests__/rollup.test.ts` here for a pure-JS encoder.
 
 ## Testing inside a Cartesi Machine
 

--- a/packages/rollup/__tests__/rollup.test.ts
+++ b/packages/rollup/__tests__/rollup.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 // `src/addon.ts` walks up to the package root to find the addon, so it loads
 // the same `.node` `dist` would. `test/machine/` covers the packed `dist` end
 // to end inside a real Cartesi Machine.
-import { Rollup, RollupError } from "../src/index.js";
+import { Rollup, RollupError, driver } from "../src/index.js";
 
 // Inputs are encoded and outputs decoded with @cartesi/codec, whose codecs are
 // derived from the rollups-contracts ABIs. libcmt encodes and decodes the same
@@ -226,27 +226,130 @@ describe("rollup", () => {
         another.close();
     });
 
-    it("drives handlers with the run loop until inputs are exhausted", async () => {
+    it("is built against the mock driver on the host", () => {
+        // the whole point of `driver`: it comes from binding.gyp's target
+        // architecture, so it is true regardless of CMT_INPUTS being set
+        expect(driver).toBe("mock");
+    });
+
+    // The mock signals "CMT_INPUTS is exhausted" through cmt_rollup_finish, with
+    // a different errno depending on how the last request ended (io-mock.c:
+    // mock_rx_accepted vs mock_rx_rejected). Both mean the same thing, so both
+    // have to end `run` cleanly — hence one test per route, plus this one
+    // pinning the external behavior the package absorbs.
+    it("reports exhaustion as -ENODATA after an accept and -ENOSYS after a reject", () => {
+        writeInputs("errno-accept", [[0, "advance.bin", advanceInput()]]);
+        const accepted = new Rollup();
+        accepted.finish();
+        const afterAccept = captureError(() =>
+            accepted.finish({ accept: true }),
+        ) as RollupError;
+        expect(afterAccept).toBeInstanceOf(RollupError);
+        expect(afterAccept.syscall).toBe("cmt_rollup_finish");
+        expect(afterAccept.errno).toBe(-os.constants.errno.ENODATA);
+        accepted.close();
+
+        writeInputs("errno-reject", [[0, "advance.bin", advanceInput()]]);
+        const rejected = new Rollup();
+        rejected.finish();
+        const afterReject = captureError(() =>
+            rejected.finish({ accept: false }),
+        ) as RollupError;
+        expect(afterReject).toBeInstanceOf(RollupError);
+        expect(afterReject.syscall).toBe("cmt_rollup_finish");
+        expect(afterReject.errno).toBe(-os.constants.errno.ENOSYS);
+        rejected.close();
+    });
+
+    it("drives handlers with the run loop until the accepted inputs are exhausted", async () => {
         const payloads = [
             Buffer.from("input-0"),
             Buffer.from("input-1"),
         ] as const;
+        const query = Buffer.from("query-0");
         writeInputs("run", [
+            [0, "a.bin", advanceInput(payloads[0])],
+            [0, "b.bin", advanceInput(payloads[1])],
+            [1, "c.bin", query],
+        ]);
+        const rollup = new Rollup();
+
+        const seen: Buffer[] = [];
+        const queried: Buffer[] = [];
+        // accepted final request: exhaustion arrives as -ENODATA
+        await expect(
+            rollup.run({
+                advance: (request) => {
+                    seen.push(request.payload);
+                },
+                inspect: (request) => {
+                    queried.push(request.payload);
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(seen).toEqual([...payloads]);
+        expect(queried).toEqual([query]);
+        rollup.close();
+    });
+
+    it("ends the run loop when the rejected final input exhausts the inputs", async () => {
+        const payloads = [
+            Buffer.from("rejected-0"),
+            Buffer.from("rejected-1"),
+        ] as const;
+        writeInputs("run-reject", [
             [0, "a.bin", advanceInput(payloads[0])],
             [0, "b.bin", advanceInput(payloads[1])],
         ]);
         const rollup = new Rollup();
 
         const seen: Buffer[] = [];
+        // rejecting a non-final input just moves on; rejecting the last one is
+        // what turns exhaustion into -ENOSYS
         await expect(
             rollup.run({
                 advance: (request) => {
                     seen.push(request.payload);
+                    return false;
                 },
             }),
-        ).rejects.toThrow(/cmt_rollup_finish failed/);
+        ).resolves.toBeUndefined();
         expect(seen).toEqual([...payloads]);
         rollup.close();
+    });
+
+    it("ends the run loop when the final input's handler throws", async () => {
+        const dir = writeInputs("run-throw", [
+            [0, "advance.bin", advanceInput()],
+        ]);
+        const rollup = new Rollup();
+
+        // a throwing handler rejects the input, so this takes the -ENOSYS route
+        await expect(
+            rollup.run({
+                advance: () => {
+                    throw new Error("handler blew up");
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(
+            fs.readFileSync(path.join(dir, "advance.report-0.bin")).toString(),
+        ).toMatch(/handler blew up/);
+        rollup.close();
+    });
+
+    it("rejects the run loop when finish fails for any other reason", async () => {
+        writeInputs("run-error", [[0, "advance.bin", advanceInput()]]);
+        const rollup = new Rollup();
+
+        // closing the device mid-run is a genuine failure, not an end of run
+        await expect(
+            rollup.run({
+                advance: (_request, rollup) => {
+                    rollup.close();
+                },
+            }),
+        ).rejects.toThrow(/closed/);
     });
 
     it("validates its arguments", () => {

--- a/packages/rollup/binding.gyp
+++ b/packages/rollup/binding.gyp
@@ -33,10 +33,15 @@
                 ["target_arch=='riscv64'", {
                     # Inside the Cartesi Machine: link the real driver build of
                     # libcmt installed by the machine-guest-tools package.
-                    "libraries": ["<(libcmt_lib)"]
+                    "libraries": ["<(libcmt_lib)"],
+                    # Which IO driver the addon ends up with is decided right
+                    # here, at build time; the define lets addon.cc report it
+                    # back to JS (`addon.driver`) without guessing.
+                    "defines": ["CMT_IO_DRIVER_IOCTL"]
                 }, {
                     # Host (development): compile libcmt sources with the mock
                     # IO driver directly into the addon.
+                    "defines": ["CMT_IO_DRIVER_MOCK"],
                     "sources": [
                         "<(libcmt_dir)/src/abi.c",
                         "<(libcmt_dir)/src/buf.c",

--- a/packages/rollup/native/addon.cc
+++ b/packages/rollup/native/addon.cc
@@ -14,6 +14,21 @@ extern "C" {
 #include <libcmt/rollup.h>
 }
 
+// Which libcmt IO driver got compiled/linked in is decided by binding.gyp from
+// the target architecture: the real kernel driver on riscv64, the mock (files +
+// CMT_INPUTS) everywhere else. It defines exactly one of these, and the addon
+// reports it back to JS so the TypeScript half never has to guess from the
+// environment.
+#if defined(CMT_IO_DRIVER_MOCK) == defined(CMT_IO_DRIVER_IOCTL)
+#error "binding.gyp must define exactly one of CMT_IO_DRIVER_MOCK / CMT_IO_DRIVER_IOCTL"
+#endif
+
+#if defined(CMT_IO_DRIVER_MOCK)
+#define CMT_IO_DRIVER_NAME "mock"
+#else
+#define CMT_IO_DRIVER_NAME "ioctl"
+#endif
+
 namespace {
 
 Napi::Error errno_error(Napi::Env env, const char *what, int rc) {
@@ -387,6 +402,7 @@ Napi::Object Rollup::Init(Napi::Env env, Napi::Object exports) {
 }
 
 Napi::Object InitModule(Napi::Env env, Napi::Object exports) {
+    exports.Set("driver", Napi::String::New(env, CMT_IO_DRIVER_NAME));
     return Rollup::Init(env, exports);
 }
 

--- a/packages/rollup/src/addon.ts
+++ b/packages/rollup/src/addon.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import nodeGypBuild from "node-gyp-build";
+import type { RollupDriver } from "./types.js";
 
 /**
  * Raw N-API surface (see native/addon.cc). Byte arguments must already be
@@ -49,6 +50,8 @@ export interface NativeGioResponse {
 
 export interface NativeAddon {
     Rollup: new () => NativeRollup;
+    /** The libcmt IO driver this addon was built against. See {@link driver}. */
+    driver: RollupDriver;
 }
 
 // Package root: walk up from this file (dist/ when bundled, src/ when executed
@@ -68,3 +71,14 @@ const findPackageRoot = (dir: string): string => {
 };
 
 export const addon = nodeGypBuild(findPackageRoot(__dirname)) as NativeAddon;
+
+/**
+ * The libcmt IO driver this addon was built against: `"ioctl"` for the real
+ * Cartesi Machine driver (riscv64), `"mock"` for the file-based simulation used
+ * on development hosts.
+ *
+ * It is decided by `binding.gyp` from the target architecture, at build time —
+ * not by the environment, so it is the truth about which half of libcmt is
+ * running, where `CMT_INPUTS` being set is only a hint.
+ */
+export const driver: RollupDriver = addon.driver;

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,3 +1,4 @@
+export { driver } from "./addon.js";
 export { ADDRESS_LENGTH, U256_LENGTH } from "./convert.js";
 export { RollupError, type RollupErrorOptions } from "./errors.js";
 export { Rollup } from "./rollup.js";
@@ -11,6 +12,7 @@ export type {
     GioResponse,
     Hex,
     InspectRequest,
+    RollupDriver,
     RollupRequest,
     RunHandlers,
     U256Like,

--- a/packages/rollup/src/rollup.ts
+++ b/packages/rollup/src/rollup.ts
@@ -1,6 +1,7 @@
-import { type NativeRollup, addon } from "./addon.js";
+import { constants } from "node:os";
+import { type NativeRollup, addon, driver } from "./addon.js";
 import { toAddress, toBytes, toHex, toU256 } from "./convert.js";
-import { bindingCall } from "./errors.js";
+import { RollupError, bindingCall } from "./errors.js";
 import type {
     BytesLike,
     DelegateCallVoucher,
@@ -13,6 +14,40 @@ import type {
 } from "./types.js";
 
 const EMPTY = Buffer.alloc(0);
+
+/**
+ * Negative errnos the *mock* IO driver uses to report "the CMT_INPUTS list is
+ * exhausted" out of `cmt_rollup_finish`. It picks one or the other depending on
+ * how the last request ended (io-mock.c): `-ENODATA` when it was accepted, and
+ * `-ENOSYS` when it was rejected — same condition, two codes, so a fix that
+ * only knows about one of them still crashes rejecting applications.
+ *
+ * errno values are platform-specific (ENODATA is 61 on Linux and 96 on macOS),
+ * hence node:os rather than literals; anything missing on a given platform is
+ * dropped instead of matching `-undefined`.
+ */
+const MOCK_EXHAUSTED_ERRNOS = new Set(
+    [constants.errno.ENODATA, constants.errno.ENOSYS]
+        .filter((errno): errno is number => typeof errno === "number")
+        .map((errno) => -errno),
+);
+
+/**
+ * Whether a failed `finish` is the mock driver saying it ran out of inputs,
+ * which is how a host test run ends normally.
+ *
+ * Gated on the driver the addon was *built* against, so the `-ENOSYS` case in
+ * particular ("function not implemented" — a plausible genuine failure from the
+ * real device or an old kernel driver) can never be swallowed inside a Cartesi
+ * Machine: there the addon links the ioctl driver and this is unreachable. And
+ * running out of inputs is a mock-only concept anyway — in a real machine the
+ * loop is meant to run forever, so even `-ENODATA` is a genuine error there.
+ */
+const isMockInputsExhausted = (error: unknown): boolean =>
+    driver === "mock" &&
+    error instanceof RollupError &&
+    error.syscall === "cmt_rollup_finish" &&
+    MOCK_EXHAUSTED_ERRNOS.has(error.errno);
 
 export class Rollup {
     #native: NativeRollup;
@@ -131,13 +166,25 @@ export class Rollup {
     /**
      * Convenience request loop. Handlers receive (request, rollup), may be
      * async, and accept the request unless they return false (exceptions
-     * reject and are reported). Runs until finish fails (e.g. mock inputs are
-     * exhausted, or the device is closed), which rejects with that error.
+     * reject and are reported).
+     *
+     * Inside a Cartesi Machine the loop never ends: it only settles if `finish`
+     * fails (e.g. the device was closed), and then it rejects with that error.
+     * On the host mock it also resolves when the inputs listed in `CMT_INPUTS`
+     * run out, which is the normal end of a test run.
      */
-    async run(handlers: RunHandlers = {}): Promise<never> {
+    async run(handlers: RunHandlers = {}): Promise<void> {
         let accept = true;
         for (;;) {
-            const request = this.finish({ accept });
+            let request: RollupRequest;
+            try {
+                request = this.finish({ accept });
+            } catch (error) {
+                if (isMockInputsExhausted(error)) {
+                    return;
+                }
+                throw error;
+            }
             try {
                 if (request.type === "advance") {
                     accept = handlers.advance

--- a/packages/rollup/src/types.ts
+++ b/packages/rollup/src/types.ts
@@ -3,6 +3,13 @@ import type { Rollup } from "./rollup.js";
 /** 0x-prefixed hex string. Compatible with viem's `Hex` and `Address`. */
 export type Hex = `0x${string}`;
 
+/**
+ * libcmt IO driver the native addon was built against: `"ioctl"` (the real
+ * Cartesi Machine kernel driver, riscv64) or `"mock"` (the file-based host
+ * simulation driven by `CMT_INPUTS`).
+ */
+export type RollupDriver = "ioctl" | "mock";
+
 /** Bytes input: 0x-prefixed hex string, Buffer or Uint8Array. */
 export type BytesLike = Hex | Uint8Array;
 


### PR DESCRIPTION
`Rollup.run` could never resolve, so host-mode testing reported failure on every successful run.

The `finish()` call sat outside the loop's `try`, so the failure libcmt's mock IO driver raises when `CMT_INPUTS` is exhausted — the *normal* end of a host test run — escaped as a rejected promise, and every such run ended in an unhandled `RollupError` and a non-zero exit. `run` now catches it and returns; anything else still rethrows.

Surfaced while removing deroll's wrapper around this package, where a `run()` shim existed purely to convert the `-ENODATA` rejection into a clean exit — it never handled `-ENOSYS`, so rejecting applications crashed even with the shim (tuler/deroll#205).

## Two exhaustion errnos, not one

The mock reports the same condition — `load_next_input` failed because `CMT_INPUTS` is exhausted — with a different errno depending on how the last request ended (`io-mock.c`):

| Last request | Path | errno |
| ------------ | ---- | ----- |
| accepted | `mock_rx_accepted` | `-ENODATA` |
| rejected | `mock_rx_rejected` | `-ENOSYS` |

Both are recognized, so applications that reject their last input also exit cleanly. Rejecting a *non-final* input is unaffected — the mock returns 0 and the loop continues. Values are read from `node:os` (`constants.errno.*`) rather than hardcoded, since `ENODATA` is 61 on Linux and 96 on macOS (`ENOSYS`: 38 / 78); an errno missing on some platform is dropped rather than matching `-undefined`.

## Detecting the mock

`-ENOSYS` ("function not implemented") is a plausible genuine failure from a real device or an older kernel driver, so swallowing it everywhere would hide real bugs. The driver is selected at **build** time by target architecture, not by an environment variable, so `CMT_INPUTS` being set is only a proxy. Instead:

- `binding.gyp` defines `CMT_IO_DRIVER_MOCK` / `CMT_IO_DRIVER_IOCTL` in the same `conditions` branches that already select the sources, so the define cannot drift from what was actually built.
- `native/addon.cc` reports it back as `addon.driver`, guarded by `#if defined(A) == defined(B)` → `#error`, so a missing or doubled define fails the build instead of yielding a silently wrong answer.
- The package exports it as `driver` (`"ioctl" | "mock"`, typed `RollupDriver`).

Gating the exhaustion check on it makes the `-ENOSYS` special case provably unreachable inside a real machine. Running until exhausted is a mock-only concept anyway — inside a machine the loop is meant to run forever, so `-ENODATA` from a real device stays a genuine error too.

## Breaking (types)

`run` returns `Promise<void>` instead of `Promise<never>`. Code relying on `never` (control-flow narrowing after `await rollup.run(...)`, or assigning the result to a `never`-typed position) no longer type-checks. The package is `1.0.0-alpha`, and the changeset calls this out. Host tests that wrapped the loop in `.catch(() => {})` to swallow the exhaustion error can drop it — they now hide real errors instead.

## Tests

Both exhaustion paths are covered under `CMT_INPUTS`, since they take different errno routes and it would be easy to fix one and not the other:

- accepted final request ends the loop cleanly (advance **and** inspect handlers, `-ENODATA`)
- rejected final input ends the loop cleanly (`-ENOSYS`), with a non-final rejection continuing first
- a throwing handler still emits its report, then ends cleanly via the reject route
- the raw errnos are pinned directly off `finish`, documenting the external behavior this package absorbs
- a genuine `finish` failure (device closed mid-run) still rejects
- `driver` is `"mock"` on the host

13 pass; `src/rollup.ts` is now at 100% statement/line coverage. `deps/machine-guest-tools` is untouched.

Verified end-to-end against the built `dist` — both reproductions from the report now exit 0:

```
--- accept path ---   handled input, driver=mock, accept=true    → run() resolved, exit=0
--- reject path ---   handled input, driver=mock, accept=false   → run() resolved, exit=0
```

The mock still prints `no revert for the mock implementation` to stderr on every rejection; that is known noise and out of scope.

## Docs

Updated the pages documenting the old contract: `run.mdx` (Returns), `handling-requests.mdx` ("When the loop ends"), `testing.mdx` (its example carried the `.catch(() => {})` this removes the need for, plus the two errnos and `driver`), `finish.mdx` (errors table) and `types.mdx` (`driver` / `RollupDriver`), and the package README.

## Notes for the reviewer

Two pre-existing issues, unrelated to this change and left alone: `@cartesi/react` fails `pnpm lint` on formatting drift in files this PR does not touch, and the docs site build cannot complete without an installed cartesi-machine emulator (`@cartesi/machine`) — the new twoslash snippets were type-checked separately against the built package instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAje9zK3xGzKBXqunQWe7V)_