### PR TITLE
feat(rollup): add chain and broadcast handler composition

### DIFF
--- a/.changeset/lucky-donkeys-compose.md
+++ b/.changeset/lucky-donkeys-compose.md
@@ -1,0 +1,5 @@
+---
+"@cartesi/rollup": minor
+---
+
+add `chain` and `broadcast`, which fold several handlers into the single one `run` takes per request kind: `chain` offers the request to each in turn and stops at the first that accepts, `broadcast` offers it to all of them. Composed handlers must return a real `boolean` — inside a composition the return value is a claim on the request, not the input's verdict, so unlike `run` (where a handler that returns nothing accepts) a missing answer has no sensible default and is a type error, and a `TypeError` for callers without types. `run` itself is unchanged. Also exports the handler types the composers work with: `RequestHandler`, `AdvanceRequestHandler` and `InspectRequestHandler`

--- a/apps/docs/pages/rollup/broadcast.mdx
+++ b/apps/docs/pages/rollup/broadcast.mdx
@@ -1,0 +1,49 @@
+# broadcast
+
+Composes handlers that **observe** the same request: every one of them is offered it, in order, whatever the others answered.
+
+Use it when several concerns react to the same request independently. See [Composing Handlers](/rollup/composing-handlers) for how it compares to [`chain`](/rollup/chain).
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import { Rollup, broadcast } from "@cartesi/rollup";
+import { app } from "./app.js";
+import { indexer } from "./indexer.js";
+
+const rollup = new Rollup();
+// ---cut---
+await rollup.run({
+    // the indexer sees every input the application processes
+    advance: broadcast(app.handler, indexer.handler),
+});
+```
+
+## Returns
+
+A handler of the same request kind, ready to pass to [`run`](/rollup/run):
+
+- `true` if **any** handler accepted,
+- `false` if they all declined — `run` then **rejects** the input, since nobody claimed it. An empty `broadcast()` declines everything.
+
+Exceptions are not caught: the first one aborts the remaining handlers and propagates to `run`, which rejects the input and emits the error as a report.
+
+## Parameters
+
+### handlers
+
+- Type: `RequestHandler[]` — `AdvanceRequestHandler` or `InspectRequestHandler`
+- Variadic
+
+The handlers, in the order they get offered the request. They may be synchronous or `async`, and always run one after another, never concurrently: they share one device and one application state, and the order in which they emit outputs is part of what the machine proves.
+
+Each must return a real `boolean` — `true` accepts the request, `false` declines it. That is stricter than the handlers [`run`](/rollup/run) takes directly, where returning nothing means accept; [Handlers must answer](/rollup/composing-handlers#handlers-must-answer) explains why.
+
+## Errors
+
+| Condition                                        | Error       |
+| ------------------------------------------------ | ----------- |
+| A handler answers with something other than a boolean | `TypeError` |
+
+Ruled out by the types, so this only reaches JavaScript callers — as a rejected input with the error in a report, rather than a request silently counted as unclaimed.

--- a/apps/docs/pages/rollup/chain.mdx
+++ b/apps/docs/pages/rollup/chain.mdx
@@ -1,0 +1,50 @@
+# chain
+
+Composes handlers that **compete** for a request: each is offered it in turn, and the first one to accept wins — the handlers after it never run.
+
+Use it when at most one handler owns a given request. See [Composing Handlers](/rollup/composing-handlers) for how it compares to [`broadcast`](/rollup/broadcast).
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import { Rollup, chain } from "@cartesi/rollup";
+import { wallet } from "./wallet.js";
+import { app } from "./app.js";
+
+const rollup = new Rollup();
+// ---cut---
+await rollup.run({
+    // the wallet claims portal deposits and declines everything else, which
+    // then falls through to the application's own logic
+    advance: chain(wallet.handler, app.handler),
+});
+```
+
+## Returns
+
+A handler of the same request kind, ready to pass to [`run`](/rollup/run):
+
+- `true` as soon as one of the handlers accepts,
+- `false` if they all decline — `run` then **rejects** the input, since nobody claimed it. An empty `chain()` declines everything.
+
+Exceptions are not caught: the first one aborts the remaining handlers and propagates to `run`, which rejects the input and emits the error as a report.
+
+## Parameters
+
+### handlers
+
+- Type: `RequestHandler[]` — `AdvanceRequestHandler` or `InspectRequestHandler`
+- Variadic
+
+The handlers, in the order they get offered the request. They may be synchronous or `async`, and always run one after another, never concurrently.
+
+Each must return a real `boolean` — `true` claims the request, `false` declines it and passes it on. That is stricter than the handlers [`run`](/rollup/run) takes directly, where returning nothing means accept; [Handlers must answer](/rollup/composing-handlers#handlers-must-answer) explains why.
+
+## Errors
+
+| Condition                                        | Error       |
+| ------------------------------------------------ | ----------- |
+| A handler answers with something other than a boolean | `TypeError` |
+
+Ruled out by the types, so this only reaches JavaScript callers — as a rejected input with the error in a report, rather than a silently misrouted request.

--- a/apps/docs/pages/rollup/composing-handlers.mdx
+++ b/apps/docs/pages/rollup/composing-handlers.mdx
@@ -1,0 +1,85 @@
+# Composing Handlers
+
+[`run`](/rollup/run) takes one handler per request kind, but an application usually has several independent concerns per kind: a wallet that claims portal deposits, the application's own logic, an indexer that watches everything go by. [`chain`](/rollup/chain) and [`broadcast`](/rollup/broadcast) fold a list of handlers into the single one `run` expects.
+
+```ts twoslash
+// @noErrors
+import { Rollup, chain, broadcast } from "@cartesi/rollup";
+import { wallet } from "./wallet.js";
+import { app } from "./app.js";
+import { indexer } from "./indexer.js";
+
+const rollup = new Rollup();
+
+await rollup.run({
+    // the wallet claims deposits; everything else falls through to the app
+    advance: chain(wallet.handler, app.handler),
+    // both answer every query, with a report each
+    inspect: broadcast(wallet.query, indexer.query),
+});
+```
+
+## Competing or observing
+
+The two composers differ in one thing: whether an accepted request is still offered to the handlers that come after.
+
+| Composer                 | Handlers                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `chain(...handlers)`     | **compete** — offered the request in turn; the first to accept wins and the rest never run          |
+| `broadcast(...handlers)` | **observe** — every one is offered the request, in order, whatever the others answered              |
+
+Reach for `chain` when at most one handler owns a given request (routing by `msgSender`, by a command in the payload, by a portal address), and for `broadcast` when several concerns react to the same request independently.
+
+Both are ordinary functions returning a handler, so they nest: `chain(wallet.handler, broadcast(app.handler, metrics.handler))` gives the wallet first refusal and lets the other two share whatever it declined.
+
+The handlers always run one after another, never concurrently — they share one device and one application state, and the order in which they emit outputs is part of what the machine proves.
+
+## Accepting, declining, rejecting
+
+Inside a composition, a handler's `boolean` is a **claim**, not a verdict: `true` accepts the request, `false` declines it and leaves it to the others. Only the composed handler's answer reaches `run`, and that is what decides the input's fate — both composers return `true` if any handler accepted and `false` if none did, so a request nobody claimed is [rejected](/rollup/handling-requests#accepting-and-rejecting).
+
+Exceptions are not caught. The first one aborts the remaining handlers and propagates to `run`, which rejects the input and emits the error as a report — which is exactly what you want, and why neither composer needs a `catch`.
+
+## Handlers must answer
+
+A composed handler must return a real `boolean`. This is stricter than `run`, which reads a handler that returns nothing as an accept:
+
+```ts twoslash
+// @errors: 2345
+import { chain } from "@cartesi/rollup";
+import type { AdvanceRequest, AdvanceRequestHandler, Rollup } from "@cartesi/rollup";
+
+const echo: AdvanceRequestHandler = (request, rollup) => {
+    rollup.emitNotice(request.payload);
+    return true;
+};
+
+// what a handler written for `run` looks like: no return statement
+const notAnswering = (request: AdvanceRequest, rollup: Rollup) => {
+    rollup.emitNotice(request.payload);
+};
+
+// ---cut---
+chain(echo, notAnswering);
+```
+
+The strictness is deliberate, and it is not the same question being answered twice. A handler passed to `run` decides the input's fate by itself, so "no answer" can safely mean accept — there is nobody else to ask. A handler inside a composition only claims the request, and there is no sensible default for a missing claim: reading it as an accept would silently swallow every handler after it, reading it as a decline would silently drop the request and reject an input `run` would have accepted. So the composers refuse to guess — the type rules it out, and for JavaScript callers a `TypeError` at runtime does, which `run` reports like any other handler failure.
+
+In practice this means a handler you want to compose declares its answer up front:
+
+```ts twoslash
+import type { AdvanceRequestHandler } from "@cartesi/rollup";
+
+const DEPOSIT = "0x0000000000000000000000000000000000000001";
+
+// a handler that only claims what it recognizes
+const wallet: AdvanceRequestHandler = (request, rollup) => {
+    if (request.msgSender !== DEPOSIT) {
+        return false; // not mine — the next handler gets it
+    }
+    rollup.emitReport(Buffer.from("deposit credited"));
+    return true;
+};
+```
+
+`AdvanceRequestHandler` and `InspectRequestHandler` (both `RequestHandler` specialized to a request kind — see [Types](/rollup/types#handler-types)) name that contract. They are assignable to the matching `run` handler, so a composed handler drops straight into `run` with no adapter.

--- a/apps/docs/pages/rollup/handling-requests.mdx
+++ b/apps/docs/pages/rollup/handling-requests.mdx
@@ -96,6 +96,8 @@ await rollup.run({
 });
 ```
 
+These are the rules for the handler `run` calls. When that handler is a composition of several — see [Composing Handlers](/rollup/composing-handlers) — the ones inside it answer a narrower question, "did I claim this request?", and only the composition's answer decides the input's fate.
+
 ## Async handlers
 
 Handlers may be `async` — `run` awaits them before finishing the request:

--- a/apps/docs/pages/rollup/run.mdx
+++ b/apps/docs/pages/rollup/run.mdx
@@ -62,3 +62,5 @@ The handler's result decides the request's fate:
 | no handler for the request type  | request **rejected**                                                      |
 
 See [Handling Requests](/rollup/handling-requests) for the semantics of accept/reject.
+
+`run` takes exactly one handler per request type. To split a request kind across several independently written handlers, fold them with [`chain`](/rollup/chain) or [`broadcast`](/rollup/broadcast) — see [Composing Handlers](/rollup/composing-handlers). Those compose handlers that must return a real `boolean`, which is assignable here.

--- a/apps/docs/pages/rollup/types.mdx
+++ b/apps/docs/pages/rollup/types.mdx
@@ -6,11 +6,14 @@ Everything the package exports besides the [`Rollup`](/rollup/Rollup) class (the
 import type {
     AddressLike,
     AdvanceRequest,
+    AdvanceRequestHandler,
     BytesLike,
     DelegateCallVoucher,
     GioResponse,
     Hex,
     InspectRequest,
+    InspectRequestHandler,
+    RequestHandler,
     RollupDriver,
     RollupRequest,
     RunHandlers,
@@ -70,6 +73,24 @@ if (request.type === "advance") {
 ## Handler types
 
 `RunHandlers` is the parameter of [`run`](/rollup/run) — an optional `advance` and `inspect` handler, each receiving `(request, rollup)` and returning `boolean | void`, possibly wrapped in a `Promise`.
+
+`RequestHandler<request>` is the handler [`chain`](/rollup/chain) and [`broadcast`](/rollup/broadcast) compose: the same `(request, rollup)`, but returning `boolean | Promise<boolean>` — inside a composition, a missing answer has no sensible meaning ([why](/rollup/composing-handlers#handlers-must-answer)). `AdvanceRequestHandler` and `InspectRequestHandler` are it, specialized to one request kind:
+
+```ts twoslash
+import type { AdvanceRequestHandler, InspectRequestHandler } from "@cartesi/rollup";
+
+const advance: AdvanceRequestHandler = (request, rollup) => {
+    rollup.emitNotice(request.payload);
+    return true;
+};
+
+const inspect: InspectRequestHandler = (request, rollup) => {
+    rollup.emitReport(request.payload);
+    return true;
+};
+```
+
+`boolean` is assignable to `boolean | void`, so either of them — composed or not — can be passed to `run` directly.
 
 ## Response types
 

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -491,6 +491,10 @@ const config: Config = defineConfig({
                             link: "/rollup/handling-requests",
                         },
                         {
+                            text: "Composing Handlers",
+                            link: "/rollup/composing-handlers",
+                        },
+                        {
                             text: "Emitting Outputs",
                             link: "/rollup/emitting-outputs",
                         },
@@ -510,6 +514,8 @@ const config: Config = defineConfig({
                         { text: "new Rollup", link: "/rollup/Rollup" },
                         { text: "finish", link: "/rollup/finish" },
                         { text: "run", link: "/rollup/run" },
+                        { text: "chain", link: "/rollup/chain" },
+                        { text: "broadcast", link: "/rollup/broadcast" },
                         { text: "emitVoucher", link: "/rollup/emitVoucher" },
                         {
                             text: "emitDelegateCallVoucher",

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -77,6 +77,30 @@ The JavaScript half of the binding is written in TypeScript (`src/*.ts`) and bun
 | `close()`                                          | Releases the device.                                                                                                 |
 | `run({ advance, inspect })`                        | Convenience loop over `finish`; handlers may be async. Handler exceptions reject the input and are emitted as reports. |
 
+### Composing handlers
+
+`run` takes one handler per request kind, but applications usually have several independent concerns per kind. Two composers fold a list of handlers into one:
+
+```js
+import { broadcast, chain } from "@cartesi/rollup";
+
+await rollup.run({
+    advance: chain(wallet.handler, app.handler), // first to accept wins
+    inspect: broadcast(balances.query, health.query), // all of them run
+});
+```
+
+| Function                | Description                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `chain(...handlers)`     | Handlers **compete**: each is offered the request in turn, and the first to return `true` wins — the rest never run. |
+| `broadcast(...handlers)` | Handlers **observe**: every one is offered the request, in order, whatever the others answered.                |
+
+Both accept the request if any handler accepted and decline (so `run` rejects the input) if none did. Neither catches exceptions — they propagate to `run`, which rejects the input and reports them.
+
+Composed handlers must return a real `boolean`, unlike the ones `run` takes directly: `true` claims the request, `false` declines it and passes it on. The two are different questions — a `run` handler decides the input's fate by itself, so returning nothing can safely mean accept, while a handler inside a composition only makes a claim, and the input is rejected when nobody claims it. A missing answer has no sensible default there (accepting would swallow the remaining handlers, declining would drop the request), so it is a type error, and a `TypeError` at runtime for callers without types.
+
+The `AdvanceRequestHandler` and `InspectRequestHandler` types name that contract; both are assignable to the corresponding `run` handler, which is why a composed handler drops straight into `run`.
+
 The package also exports `driver`, the libcmt IO driver the addon was built against: `"ioctl"` inside the machine, `"mock"` on the host. It is decided at build time by the target architecture, so it is a reliable "am I running for real?" check.
 
 Failed libcmt calls throw a `RollupError` with the negative errno in `error.errno` and the failed call in `error.syscall`.

--- a/packages/rollup/__tests__/handlers.test.ts
+++ b/packages/rollup/__tests__/handlers.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+// `chain` and `broadcast` are pure functions over the handler types: they never
+// touch the device, so this suite imports them straight from their module
+// rather than from `src/index.js`, which loads the native addon. Nothing here
+// needs a built addon or CMT_INPUTS.
+import { broadcast, chain } from "../src/handlers.js";
+import type { Rollup } from "../src/rollup.js";
+import type {
+    AdvanceRequest,
+    AdvanceRequestHandler,
+    RunHandlers,
+} from "../src/types.js";
+
+// the composers only pass these two through, so identity is all that matters —
+// no device is ever touched (the `Rollup` import above is type-only)
+const REQUEST = { type: "advance", index: 7n } as AdvanceRequest;
+const ROLLUP = {} as Rollup;
+
+/** A handler that records the call and answers with `accepted`. */
+const handler = (
+    name: string,
+    calls: string[],
+    accepted: boolean,
+): AdvanceRequestHandler => {
+    return (request, rollup) => {
+        expect(request).toBe(REQUEST);
+        expect(rollup).toBe(ROLLUP);
+        calls.push(name);
+        return accepted;
+    };
+};
+
+/** The same, asynchronous, so the composers have something to await. */
+const asyncHandler = (
+    name: string,
+    calls: string[],
+    accepted: boolean,
+): AdvanceRequestHandler => {
+    const sync = handler(name, calls, accepted);
+    return async (request, rollup) => {
+        await Promise.resolve();
+        return sync(request, rollup);
+    };
+};
+
+const throwing =
+    (error: Error): AdvanceRequestHandler =>
+    () => {
+        throw error;
+    };
+
+// what a handler written for `run` looks like: no return statement, which
+// `run` reads as an accept. The type rejects it here, so composing one is a
+// deliberate act — hence the casts below, which stand in for the JavaScript
+// caller the runtime check exists for.
+const voidHandler = (() => {}) as unknown as AdvanceRequestHandler;
+
+describe("chain", () => {
+    it("stops at the first handler that accepts", async () => {
+        const calls: string[] = [];
+        await expect(
+            chain(
+                handler("a", calls, false),
+                asyncHandler("b", calls, true),
+                handler("c", calls, false),
+            )(REQUEST, ROLLUP),
+        ).resolves.toBe(true);
+        // "c" never ran: the request was already claimed
+        expect(calls).toEqual(["a", "b"]);
+    });
+
+    it("declines when every handler declines", async () => {
+        const calls: string[] = [];
+        await expect(
+            chain(handler("a", calls, false), asyncHandler("b", calls, false))(
+                REQUEST,
+                ROLLUP,
+            ),
+        ).resolves.toBe(false);
+        expect(calls).toEqual(["a", "b"]);
+    });
+
+    it("declines when there are no handlers", async () => {
+        await expect(chain()(REQUEST, ROLLUP)).resolves.toBe(false);
+    });
+
+    it("lets a handler's exception through, aborting the rest", async () => {
+        const calls: string[] = [];
+        const error = new Error("handler blew up");
+        await expect(
+            chain(
+                handler("a", calls, false),
+                throwing(error),
+                handler("c", calls, false),
+            )(REQUEST, ROLLUP),
+        ).rejects.toBe(error);
+        expect(calls).toEqual(["a"]);
+    });
+
+    it("rejects a handler that answers with something other than a boolean", async () => {
+        const calls: string[] = [];
+        // a `void` handler must not be read as "declined" behind the caller's
+        // back — that would silently pass the request on and end up rejecting
+        // an input `run` would have accepted
+        await expect(
+            chain(voidHandler, handler("b", calls, true))(REQUEST, ROLLUP),
+        ).rejects.toThrow(TypeError);
+        await expect(chain(voidHandler)(REQUEST, ROLLUP)).rejects.toThrow(
+            /must return a boolean.*got undefined/,
+        );
+        expect(calls).toEqual([]);
+    });
+});
+
+describe("broadcast", () => {
+    it("offers the request to every handler, in order", async () => {
+        const calls: string[] = [];
+        await expect(
+            broadcast(
+                handler("a", calls, false),
+                asyncHandler("b", calls, true),
+                handler("c", calls, false),
+            )(REQUEST, ROLLUP),
+        ).resolves.toBe(true);
+        // unlike `chain`, "b" accepting does not stop "c"; and the handlers run
+        // one after another, not concurrently
+        expect(calls).toEqual(["a", "b", "c"]);
+    });
+
+    it("accepts if any handler accepted", async () => {
+        const calls: string[] = [];
+        await expect(
+            broadcast(
+                asyncHandler("a", calls, true),
+                handler("b", calls, true),
+            )(REQUEST, ROLLUP),
+        ).resolves.toBe(true);
+        expect(calls).toEqual(["a", "b"]);
+    });
+
+    it("declines when every handler declines, and when there are none", async () => {
+        const calls: string[] = [];
+        await expect(
+            broadcast(
+                handler("a", calls, false),
+                asyncHandler("b", calls, false),
+            )(REQUEST, ROLLUP),
+        ).resolves.toBe(false);
+        expect(calls).toEqual(["a", "b"]);
+        await expect(broadcast()(REQUEST, ROLLUP)).resolves.toBe(false);
+    });
+
+    it("lets a handler's exception through, aborting the rest", async () => {
+        const calls: string[] = [];
+        const error = new Error("handler blew up");
+        await expect(
+            broadcast(
+                handler("a", calls, true),
+                throwing(error),
+                handler("c", calls, false),
+            )(REQUEST, ROLLUP),
+        ).rejects.toBe(error);
+        expect(calls).toEqual(["a"]);
+    });
+
+    it("rejects a handler that answers with something other than a boolean", async () => {
+        await expect(broadcast(voidHandler)(REQUEST, ROLLUP)).rejects.toThrow(
+            TypeError,
+        );
+    });
+});
+
+describe("composition types", () => {
+    it("produces handlers `run` takes", () => {
+        const calls: string[] = [];
+        // the point of the looser `RunHandlers` type: `boolean` is assignable
+        // to `boolean | void`, so a composed handler drops straight into `run`
+        const handlers: RunHandlers = {
+            advance: chain(handler("a", calls, true)),
+            inspect: broadcast(),
+        };
+        expect(handlers.advance).toBeTypeOf("function");
+
+        // ...while the reverse is a type error: a handler with no return
+        // statement cannot be composed, which is the whole point
+        // @ts-expect-error a composed handler must return a boolean
+        chain(() => {});
+    });
+});

--- a/packages/rollup/src/handlers.ts
+++ b/packages/rollup/src/handlers.ts
@@ -1,0 +1,79 @@
+import type { RequestHandler, RollupRequest } from "./types.js";
+
+/**
+ * Await a handler's answer and insist that there is one.
+ *
+ * {@link RequestHandler} already rules out a handler that falls off its end,
+ * which settles it for TypeScript callers. This is the JavaScript half: a
+ * `void`-returning handler — the shape `Rollup.run` accepts and reads as an
+ * accept — would otherwise count as *declined* here, silently passing the
+ * request on and rejecting the input once the handlers run out. Throwing turns
+ * that into the loud version: `run` rejects the input and emits this message as
+ * a report, naming the handler contract that was broken.
+ */
+const answer = async (result: boolean | Promise<boolean>): Promise<boolean> => {
+    const accepted = await result;
+    if (typeof accepted !== "boolean") {
+        throw new TypeError(
+            `composed handler must return a boolean (true accepts the request, false declines it), got ${typeof accepted}`,
+        );
+    }
+    return accepted;
+};
+
+/**
+ * Compose handlers that *compete* for the request: each is offered it in turn
+ * and the first one to accept (return `true`) wins, so the rest never run. Use
+ * it when at most one handler owns a given request — a portal deposit claimed
+ * by a wallet, then the application's own logic:
+ *
+ * ```ts
+ * await rollup.run({ advance: chain(wallet.handler, app.handler) });
+ * ```
+ *
+ * The composed handler returns `true` as soon as one accepts and `false` when
+ * they all decline (an empty `chain()` declines everything), which is what
+ * `run` turns into rejecting the input: an input nobody claimed was not
+ * processed. Exceptions are deliberately not caught — they propagate to `run`,
+ * which rejects the input and reports them.
+ */
+export const chain =
+    <request extends RollupRequest>(
+        ...handlers: RequestHandler<request>[]
+    ): RequestHandler<request> =>
+    async (request, rollup) => {
+        for (const handler of handlers) {
+            if (await answer(handler(request, rollup))) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+/**
+ * Compose handlers that *observe* the same request: every one of them is
+ * offered it, in order, regardless of what the previous ones answered. Use it
+ * when several concerns react to the same input independently — an indexer, a
+ * metrics collector, the application logic.
+ *
+ * The composed handler accepts if *any* handler accepted, so a request no
+ * handler claimed still ends up rejected. The handlers run one after another
+ * rather than concurrently: they share one rollup device and one application
+ * state, and the order in which they emit outputs is part of what the machine
+ * proves. Exceptions are deliberately not caught — the first one aborts the
+ * remaining handlers and propagates to `run`, which rejects the input and
+ * reports it.
+ */
+export const broadcast =
+    <request extends RollupRequest>(
+        ...handlers: RequestHandler<request>[]
+    ): RequestHandler<request> =>
+    async (request, rollup) => {
+        let accepted = false;
+        for (const handler of handlers) {
+            if (await answer(handler(request, rollup))) {
+                accepted = true;
+            }
+        }
+        return accepted;
+    };

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,10 +1,12 @@
 export { driver } from "./addon.js";
 export { ADDRESS_LENGTH, U256_LENGTH } from "./convert.js";
 export { RollupError, type RollupErrorOptions } from "./errors.js";
+export { broadcast, chain } from "./handlers.js";
 export { Rollup } from "./rollup.js";
 export type {
     AddressLike,
     AdvanceRequest,
+    AdvanceRequestHandler,
     BytesLike,
     DelegateCallVoucher,
     FinishOptions,
@@ -12,6 +14,8 @@ export type {
     GioResponse,
     Hex,
     InspectRequest,
+    InspectRequestHandler,
+    RequestHandler,
     RollupDriver,
     RollupRequest,
     RunHandlers,

--- a/packages/rollup/src/types.ts
+++ b/packages/rollup/src/types.ts
@@ -84,6 +84,34 @@ export interface FinishOptions {
 }
 
 /**
+ * A handler of a single kind of request, as composed by `chain` and
+ * `broadcast`.
+ *
+ * It must *say* whether it accepted the request — `true` claims it, `false`
+ * declines it and leaves it to the other handlers — which is why this is
+ * `boolean` and not the `boolean | void` {@link RunHandlers} takes. The two
+ * answer different questions: a `run` handler decides the input's fate on its
+ * own, so "no answer" can safely mean accept, while a composed handler only
+ * makes a claim and the input is rejected when nobody makes one. There a
+ * missing answer has no sensible default (accepting would swallow the
+ * remaining handlers, declining would drop the request), so a handler that
+ * falls off its end is a type error instead.
+ *
+ * The reverse direction is fine: `boolean` is assignable to `boolean | void`,
+ * so a composed handler goes straight into {@link Rollup.run}.
+ */
+export type RequestHandler<request extends RollupRequest = RollupRequest> = (
+    request: request,
+    rollup: Rollup,
+) => boolean | Promise<boolean>;
+
+/** A {@link RequestHandler} of advance requests. */
+export type AdvanceRequestHandler = RequestHandler<AdvanceRequest>;
+
+/** A {@link RequestHandler} of inspect requests. */
+export type InspectRequestHandler = RequestHandler<InspectRequest>;
+
+/**
  * Handlers for {@link Rollup.run}. A handler accepts the request unless it
  * returns `false`.
  */


### PR DESCRIPTION
Stacked on #157 — based on its head, so the diff here is the single commit on top.

`Rollup.run` takes one advance handler and one inspect handler, but applications have several independently authored concerns per request kind: a wallet that claims portal deposits, then the application's own logic, then whatever watches inputs go by. Today each consumer writes its own fold. `chain` and `broadcast` fold a list of handlers into the single one `run` expects.

```ts
await rollup.run({
    advance: chain(wallet.handler, app.handler), // first to accept wins
    inspect: broadcast(balances.query, health.query), // all of them run
});
```

| Composer                 | Handlers                                                                                   |
| ------------------------ | ------------------------------------------------------------------------------------------ |
| `chain(...handlers)`     | **compete** — offered the request in turn; the first to accept wins and the rest never run   |
| `broadcast(...handlers)` | **observe** — every one is offered the request, in order, whatever the others answered       |

Both accept if any handler accepted and decline if none did, which `run` turns into rejecting the input: a request nobody claimed was not processed. Neither catches exceptions — they propagate to `run`, which rejects the input and reports them, so neither needs a `catch`. Handlers run sequentially, never concurrently: they share one device and one application state, and the order in which they emit outputs is part of what the machine proves.

Both are generic over the request kind, so one implementation serves advance and inspect handlers alike, and they nest — `chain(wallet.handler, broadcast(app.handler, metrics.handler))` gives the wallet first refusal and lets the other two share what it declined.

Ported from deroll's `@deroll/core`, which is these two functions and nothing else; if this lands, that package disappears.

## Why `run` is unchanged

The interesting question is that `run` treats a missing return as accept (`await handlers.advance(...) !== false`), while these composers need a real boolean — move them in unchanged and the same handler would mean opposite things depending on how it was passed.

That trap is real, but the two return values are not the same value being read two ways:

- In `run`, the handler's answer **is the input's fate**. It decides alone, so "no answer" can safely mean accept.
- In a composition, the answer is a **claim** — "this one is mine". The fate is derived: the input is rejected only when nobody claimed it, and returning `false` rejects nothing, it defers.

So the strict boolean is applied where the ambiguity actually exists. `RequestHandler` returns `boolean`, not `boolean | void`; a handler that falls off its end is a type error at the point of composition, and the message is the honest one — *a handler written for `run` is not a composable handler*. `boolean` is assignable to `boolean | void`, so a composed handler still drops straight into `run` with no adapter.

Tightening `RunHandlers` to match was the alternative, and it is worse on the merits, not just in cost. It would delete a documented convenience — `inspect(request, rollup) { rollup.emitReport(...) }` — that has no ambiguity in it, to satisfy a constraint that only exists under composition. And it would not buy the consistency it promises: closing the runtime split would mean flipping `run` from `!== false` to `=== true`, which silently turns accept into reject for existing untyped applications — a break with no diagnostic, in the worst direction. Tightening only the type is loud but leaves that runtime split intact.

## The JavaScript half

Types only bind TypeScript callers, so the composers also **throw a `TypeError` when a handler answers with something other than a boolean**, rather than reading it as declined. `run` catches it, rejects the input and emits the message as a report — a named failure instead of a request silently misrouted past every remaining handler and an input rejected that `run` would have accepted.

This is what makes the resolution complete rather than partial: there is now no configuration, typed or untyped, in which a `void`-returning handler is quietly treated as declining. It is a deliberate divergence from deroll's implementation — strictly stronger, and identical for correct code.

## API

New exports from `@cartesi/rollup`: `chain`, `broadcast`, and the types they work with — `RequestHandler<request>`, `AdvanceRequestHandler`, `InspectRequestHandler`. `run`, `RunHandlers` and the rest of the class are untouched; this is additive.

## Tests

`__tests__/handlers.test.ts`, 11 cases. They need no device — the composers are pure functions over the handler types, so the suite passes a plain object as the `rollup` argument and imports `src/handlers.js` directly rather than `src/index.js`, which would load the native addon.

- `chain` stops at the first handler that accepts; the ones after it never run
- `chain` declines when every handler declines, and when there are none
- `broadcast` offers the request to every handler even after one accepted, in order
- `broadcast` accepts if any accepted; declines when all decline or there are none
- both let a handler's exception through, aborting the remaining handlers
- both throw a `TypeError` on a non-boolean answer, on the first handler, before the rest run
- a composed handler is assignable to `RunHandlers`, and a `void` handler is not composable (`@ts-expect-error`, checked by `check-types` since the tsconfig includes `__tests__`)

Full package suite: 24 pass. `tsc --noEmit` and `biome check` clean, package builds, and the docs site builds with the new twoslash snippets type-checked — including the one asserting that composing a `void` handler *is* a compile error, which twoslash fails the build over if the error does not materialize.

## Docs

New "Composing Handlers" guide page and `chain` / `broadcast` API pages, wired into the sidebar. Updated `run.mdx` (points at the composers), `handling-requests.mdx` (the accept/reject rules are the composition's answer, not each handler's) and `types.mdx` (the new handler types), plus the package README.

## Notes for the reviewer

Nothing here is device-dependent, so the interesting review surface is the semantic call above rather than the ~25 lines under it.

Three environment snags hit while verifying, all pre-existing and unrelated: `deps/machine-guest-tools` starts uninitialized in a fresh clone (the addon does not compile until `git submodule update --init`), `@cartesi/machine` needs its TypeScript half built before the docs site can type-check, and the `wagmi generate` tarball downloads fail intermittently when codec and client run them concurrently — sequential retries succeeded every time. Worth noting that the docs build does complete now, which the note on #157 said it could not.

---
_Generated by [Claude Code](https://claude.ai/code/session_016x9jUxzHKRtiCiHDKySAUw)_