### PR TITLE
Fix docs site twoslash type-checking with TypeScript v6

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -28,6 +28,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "typescript": "catalog:",
+        "typescript-v6": "npm:typescript@^6.0.3",
         "viem": "catalog:"
     },
     "engines": {

--- a/apps/docs/vocs.config.ts
+++ b/apps/docs/vocs.config.ts
@@ -1,4 +1,62 @@
+import { createRequire } from "node:module";
+import * as path from "node:path";
 import { type Config, defineConfig } from "vocs/config";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * The TypeScript module twoslash type-checks the code blocks with.
+ *
+ * vocs would otherwise `require("typescript")` from this package, which the
+ * workspace catalog pins to v7. v7 is the native compiler: its entry point
+ * only exports `version`/`versionMajorMinor`, so twoslash's `ts.sys.readFile`
+ * throws and every code block fails to render. v6 is the last line shipping
+ * the JavaScript compiler API twoslash drives.
+ *
+ * It is aliased rather than pinning this package to v6, so that `typescript`
+ * itself stays on the catalog version: viem declares an optional `typescript`
+ * peer, so a v6 pin here would resolve a second viem instance whose types are
+ * distinct from the one `@cartesi/client` was built against, and every snippet
+ * mixing the two would fail to typecheck.
+ */
+type TsModule = NonNullable<
+    NonNullable<Extract<Config["twoslash"], object>>["twoslashOptions"]
+>["tsModule"];
+
+const typescript = require("typescript-v6") as TsModule;
+
+/**
+ * The directory twoslash's virtual file system reads `lib.*.d.ts` from.
+ *
+ * `@typescript/vfs` defaults it to `dirname(require.resolve("typescript"))`,
+ * which resolves to the v7 package — whose `lib` holds no `lib.*.d.ts` at all,
+ * so every snippet fails with `TSVFS: A request was made for lib.es2020.d.ts`.
+ * Point it at the v6 lib next to the compiler above.
+ */
+const tsLibDirectory = path.dirname(require.resolve("typescript-v6"));
+
+/**
+ * Twoslash options carrying the compiler above, with `tsModule` hidden from
+ * `Object.keys`.
+ *
+ * vocs ships the resolved config to the browser through `serializeFunctions`,
+ * which walks every enumerable key and rewrites each function it finds as
+ * source text for the client to `eval`. An enumerable `tsModule` would drag
+ * the whole TypeScript module into that walk, and its functions close over
+ * bundler-internal names, so each one throws `ReferenceError` while rendering.
+ *
+ * Non-enumerable keeps it out of the walk while leaving it readable where it
+ * matters: vocs resolves the config with a shallow spread, and reads
+ * `twoslashOptions.tsModule` directly before handing it to `createTwoslasher`.
+ * The `checkOnly` path re-spreads these options instead, and would drop it —
+ * so leave `twoslash.checkOnly` off.
+ */
+const twoslashOptions = Object.defineProperty({ tsLibDirectory }, "tsModule", {
+    value: typescript,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+}) as { tsLibDirectory: string; tsModule: TsModule };
 
 /** Minimal structural view of the hast nodes this plugin walks. */
 type HastNode = {
@@ -51,6 +109,7 @@ const config: Config = defineConfig({
     markdown: {
         rehypePlugins: [rehypeViemDocLinks],
     },
+    twoslash: { twoslashOptions },
     // GitHub Pages deployment requires fully static output
     renderStrategy: "full-static",
     title: "Cartesi",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      typescript-v6:
+        specifier: npm:typescript@^6.0.3
+        version: typescript@6.0.3
       viem:
         specifier: ^2.55.7
         version: 2.55.7(typescript@7.0.2)(zod@4.3.6)
@@ -5517,6 +5520,11 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
@@ -11979,6 +11987,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:


### PR DESCRIPTION
## Summary

The docs site uses twoslash to type-check code blocks, but the workspace pins TypeScript to v7, which only exports the native compiler without the JavaScript compiler API that twoslash requires. This change adds TypeScript v6 as an aliased dependency and configures twoslash to use it for type-checking while keeping the workspace on v7.

## Key Changes

- Added `typescript-v6` as an aliased npm dependency (`npm:typescript@^6.0.3`) in `apps/docs/package.json`
- Updated `apps/docs/vocs.config.ts` to:
  - Import and require `typescript-v6` for use as the twoslash compiler module
  - Configure the twoslash virtual file system to read type definitions from the v6 package's `lib` directory (v7's lib contains no `.d.ts` files)
  - Create a `twoslashOptions` object with `tsModule` as a non-enumerable property to prevent it from being serialized to the browser (where it would fail due to bundler-internal closures)
  - Pass `twoslashOptions` to the vocs config's `twoslash` setting

## Implementation Details

The `tsModule` property is intentionally non-enumerable to work around vocs's `serializeFunctions` mechanism, which walks enumerable keys and rewrites functions as source text for client-side evaluation. Since TypeScript's functions close over bundler-internal names, they would throw `ReferenceError` in the browser. The non-enumerable approach keeps the module available where vocs reads it directly (before handing it to `createTwoslasher`) while hiding it from serialization.

The v6 alias approach avoids pinning the workspace's `typescript` dependency, which would create a second viem instance with distinct types from what `@cartesi/client` was built against, causing type-checking failures in snippets mixing the two.

https://claude.ai/code/session_01QPZSWnbteP5qTLywt4D2cg